### PR TITLE
Update arduino/arduino-lint-action configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,3 +5,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update


### PR DESCRIPTION
The repository infrastructure uses the [**arduino/arduino-lint-action**](https://github.com/arduino/arduino-lint-action) GitHub Actions action to check for various problems with the library structure and metadata.

Some of the action's rules relate to compliance with the requirements for inclusion in the Arduino Library Manager. Different rules are applicable depending on whether the library is being prepared for eventual [submission to Library Manager](https://github.com/arduino/library-registry#adding-a-library-to-library-manager) vs. after it has been added. The action has a [`library-manager` input](https://github.com/arduino/arduino-lint-action#library-manager) that is used to configure it according to the library's Library Manager inclusion status.

The library has now been added to Library Manager (https://github.com/arduino/library-registry/pull/4152). This means that the [default configuration](https://github.com/arduino/arduino-lint-action#library-manager:~:text=Manager%2Dspecific%20checks.-,Default,-%3A%20submit%20for) of the **arduino/arduino-lint-action** action (`library-manager: submit`) is no longer appropriate. This caused the workflow to fail:

https://github.com/PowerFeather/powerfeather-sdk/actions/runs/8120449703/job/22197670094#step:3:16

```text
ERROR: Library name PowerFeather-SDK is in use by a library in the Library Manager index. Each library must have a      
       unique name value. If your library is already in the index, use the "--library-manager update" flag.             
       See: https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format           
       (Rule LP017)                                                                                                     
```

The configuration is here adjusted according to the library's new status of being included in Arduino Library Manager. This will cause the **arduino/arduino-lint-action** action to run the rules that check for problems that would cause new releases of the library to be rejected by the Library Manager indexer system.
