### PR TITLE
Fix issues and add tests

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -7,4 +7,4 @@ repository: "https://github.com/PowerFeather/powerfeather-sdk.git"
 issues: "https://github.com/PowerFeather/powerfeather-sdk/issues"
 license: "PowerFeather 4-Clause License"
 dependencies:
-  idf: ">=4.4,<=5.5"
+  idf: ">=5.2,<=5.5"

--- a/src/Mainboard/BQ2562x.cpp
+++ b/src/Mainboard/BQ2562x.cpp
@@ -119,8 +119,9 @@ namespace PowerFeather
 
         if (_readReg(IBUS_ADC, value))
         {
-            uint16_t origin = (value >= 0x7830 && value <= 0x7fff) ? 0x7fff + 1 : 0;
-            current = round(Util::fromRaw(value, 2.0f, origin));
+            // IBUS_ADC is 15-bit signed (bits 1-15).
+            int16_t raw = static_cast<int16_t>(value << 1) >> 1;
+            current = round(raw * 2.0f);
             return true;
         }
         return false;
@@ -139,14 +140,16 @@ namespace PowerFeather
 
     bool BQ2562x::getIBAT(int16_t &current)
     {
+        // 0x2000 is an invalid value carried over from bq25622e.
         static constexpr uint16_t invalid = 0x2000;
         uint16_t value = 0;
         if (_readReg(IBAT_ADC, value))
         {
             if (value != invalid)
             {
-                uint16_t origin = (value >= 0x38ad && value <= 0x3fff) ? 0x3fff + 1 : 0;
-                current = round(Util::fromRaw(value, 4.0f, origin));
+                // IBAT_ADC is 14-bit signed (bits 2-15).
+                int16_t raw = static_cast<int16_t>(value << 2) >> 2;
+                current = round(raw * 4.0f);
                 return true;
             }
         }

--- a/src/Mainboard/BQ2562x.cpp
+++ b/src/Mainboard/BQ2562x.cpp
@@ -425,6 +425,10 @@ namespace PowerFeather
 
     bool BQ2562x::setIbatPk(IbatPkLimit limit)
     {
+        if (limit == IbatPkLimit::Reserved00 || limit == IbatPkLimit::Reserved01)
+        {
+            return false;
+        }
         uint8_t value = static_cast<uint8_t>(limit);
         return _writeReg(Charger_Control_3_IBAT_PK, value);
     }

--- a/src/Mainboard/BQ2562x.h
+++ b/src/Mainboard/BQ2562x.h
@@ -153,10 +153,14 @@ namespace PowerFeather
 
         enum class IbatPkLimit : uint8_t
         {
-            Limit1_5A = 0x00,
-            Limit3A = 0x01,
+            Reserved00 = 0x00,
+            Reserved01 = 0x01,
             Limit6A = 0x02,
-            Limit12A = 0x03
+            Limit12A = 0x03,
+            // Backward-compatible aliases for legacy code. Current TI datasheets
+            // for both BQ25622E and BQ25628E mark these encodings as reserved.
+            Limit1_5A = Reserved00,
+            Limit3A = Reserved01
         };
 
         enum class TH456Setting : uint8_t

--- a/src/Mainboard/BQ2562x.h
+++ b/src/Mainboard/BQ2562x.h
@@ -293,8 +293,11 @@ namespace PowerFeather
         const Register Part_Information_PN =                  { 0x38, 1, 3, 5 };
         const Register Part_Information_DEV_REV =             { 0x38, 1, 0, 2 };
 
+    public:
         static constexpr uint8_t Charger_PN_BQ25622 = 0x03;
+        static constexpr uint8_t Charger_PN_BQ25628 = 0x04;
 
+    private:
         static constexpr uint8_t _i2cAddress = 0x6a;
 
         MasterI2C &_i2c;

--- a/src/Mainboard/BQ2562x.h
+++ b/src/Mainboard/BQ2562x.h
@@ -293,6 +293,8 @@ namespace PowerFeather
         const Register Part_Information_PN =                  { 0x38, 1, 3, 5 };
         const Register Part_Information_DEV_REV =             { 0x38, 1, 0, 2 };
 
+        static constexpr uint8_t Charger_PN_BQ25622 = 0x03;
+
         static constexpr uint8_t _i2cAddress = 0x6a;
 
         MasterI2C &_i2c;

--- a/src/Mainboard/FuelGauge.h
+++ b/src/Mainboard/FuelGauge.h
@@ -203,6 +203,11 @@ namespace PowerFeather
 {
     inline bool FuelGauge::init(const InitConfig &config, bool forceReinit)
     {
+        if (!probe())
+        {
+            return false;
+        }
+
         bool inited = false;
         if (!getInitialized(inited))
         {

--- a/src/Mainboard/FuelGauge.h
+++ b/src/Mainboard/FuelGauge.h
@@ -85,7 +85,7 @@ namespace PowerFeather
 
         FuelGauge(MasterI2C &i2c) : _i2c(i2c) {}
 
-        bool init(const InitConfig &config);
+        bool init(const InitConfig &config, bool forceReinit = false);
 
         virtual bool getEnabled(bool &enabled) = 0;
         virtual bool getCellVoltage(uint16_t &voltage) = 0;
@@ -201,7 +201,7 @@ namespace PowerFeather
 
 namespace PowerFeather
 {
-    inline bool FuelGauge::init(const InitConfig &config)
+    inline bool FuelGauge::init(const InitConfig &config, bool forceReinit)
     {
         bool inited = false;
         if (!getInitialized(inited))
@@ -209,7 +209,7 @@ namespace PowerFeather
             return false;
         }
 
-        if (inited)
+        if (!forceReinit && inited)
         {
             return true;
         }

--- a/src/Mainboard/FuelGauge.h
+++ b/src/Mainboard/FuelGauge.h
@@ -80,6 +80,7 @@ namespace PowerFeather
 
             InitSource source{InitSource::Generic_3V7};
             Payload data{};
+            bool tsenseEnabled{false};
         };
 
         FuelGauge(MasterI2C &i2c) : _i2c(i2c) {}
@@ -253,7 +254,7 @@ namespace PowerFeather
             }
         }
 
-        if (!enableTSENSE(false, false))
+        if (!enableTSENSE(config.tsenseEnabled, false))
         {
             return false;
         }

--- a/src/Mainboard/FuelGauge.h
+++ b/src/Mainboard/FuelGauge.h
@@ -62,6 +62,7 @@ namespace PowerFeather
             {
                 uint16_t capacityMah;
                 uint16_t terminationCurrentMa;
+                uint16_t chargeVoltageMv;
             };
 
             struct ProfileConfig
@@ -74,7 +75,7 @@ namespace PowerFeather
                 CapacityConfig capacity;
                 ProfileConfig profile;
 
-                constexpr Payload() : capacity{0, 0} {}
+                constexpr Payload() : capacity{0, 0, 0} {}
             };
 
             InitSource source{InitSource::Generic_3V7};

--- a/src/Mainboard/LC709204F.cpp
+++ b/src/Mainboard/LC709204F.cpp
@@ -184,6 +184,8 @@ namespace PowerFeather
         uint16_t value = 0;
         if (readRegister(static_cast<uint8_t>(Register::TSENSE1), value))
         {
+            // 0x0DCC is the 80 °C anchor (353.15 K). Ideal raw value is 3531.5.
+            // Using 0x0DCC introduces a fixed +0.05 °C bias.
             temperature = Util::fromRaw(value, 0.1, 0x0DCC) + 80.0f;
             return true;
         }
@@ -275,13 +277,20 @@ namespace PowerFeather
 
     bool LC709204F::setCellTemperature(float temperature)
     {
+        // 0xDCC is the 80 °C anchor. See getCellTemperature() for bias details.
         uint16_t value = Util::toRaw(temperature - 80.0f, 0.1f, 0xDCC);
         return writeRegister(static_cast<uint8_t>(Register::TSENSE1), value);
     }
 
     bool LC709204F::enableTSENSE(bool enableTsense1, bool enableTsense2)
     {
-        uint16_t status = enableTsense1 << 0 | enableTsense2 << 1;
+        uint16_t status = 0;
+        if (!readRegister(static_cast<uint8_t>(Register::Status_Bit), status))
+        {
+            return false;
+        }
+        status &= ~0x0003;
+        status |= (enableTsense1 << 0 | enableTsense2 << 1);
         return writeRegister(static_cast<uint8_t>(Register::Status_Bit), status);
     }
 

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -209,7 +209,12 @@ namespace PowerFeather
         }
 
         modelCfg &= static_cast<uint16_t>(~ModelCfgMask_ModelID);
+        modelCfg &= static_cast<uint16_t>(~ModelCfgBit_VChg);
         modelCfg |= static_cast<uint16_t>((modelId & 0x7u) << 5);
+        if (config.data.capacity.chargeVoltageMv > ModelCfgHighVoltageThresholdMv)
+        {
+            modelCfg |= ModelCfgBit_VChg;
+        }
         modelCfg |= ModelCfgBit_Refresh;
 
         if (!writeRegister(Register::ModelCfg, modelCfg))

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -199,6 +199,7 @@ namespace PowerFeather
         if (!writeRegister(Register::Command, HibernateExit_Command2)) return false;
 
         if (!writeRegister(Register::DesignCap, _capacityMahToDesignCapRaw(config.data.capacity.capacityMah))) return false;
+        // This will be overwritten by _finalizeInit() with potentially better accuracy
         if (!writeRegister(Register::IChgTerm, _currentMaToRaw(config.data.capacity.terminationCurrentMa))) return false;
         if (!writeRegister(Register::VEmpty, VEmpty_Default)) return false;
 

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -299,32 +299,83 @@ namespace PowerFeather
         if (!writeRegister(Register::HibCfg, HibernateExit_Command2)) return false;
         if (!writeRegister(Register::Command, HibernateExit_Command2)) return false;
 
-        if (!writeRegister(Register::UnlockModel1, UnlockKey1)) return false;
-        if (!writeRegister(Register::UnlockModel2, UnlockKey2)) return false;
-
         const uint8_t modelTableBase = static_cast<uint8_t>(Register::ModelTableStart);
-        for (size_t i = 0; i < 16; ++i)
+        bool modelVerified = false;
+        for (int attempt = 0; attempt < 3; ++attempt)
         {
-            if (!writeRegister(static_cast<uint8_t>(modelTableBase + i), model.modelTable[i]))
+            if (!writeRegister(Register::UnlockModel1, UnlockKey1)) return false;
+            if (!writeRegister(Register::UnlockModel2, UnlockKey2)) return false;
+
+            for (size_t i = 0; i < 32; ++i)
             {
-                return false;
+                if (!writeRegister(static_cast<uint8_t>(modelTableBase + i), model.modelTable[i]))
+                {
+                    return false;
+                }
+            }
+
+            if (!writeRegister(Register::RCompSeg, model.rCompSeg)) return false;
+
+            modelVerified = true;
+            for (size_t i = 0; i < 32; ++i)
+            {
+                uint16_t val = 0;
+                if (!readRegister(static_cast<uint8_t>(modelTableBase + i), val) || val != model.modelTable[i])
+                {
+                    modelVerified = false;
+                    break;
+                }
+            }
+
+            if (modelVerified)
+            {
+                uint16_t rCompSegVal = 0;
+                if (!readRegister(Register::RCompSeg, rCompSegVal) || rCompSegVal != model.rCompSeg)
+                {
+                    modelVerified = false;
+                }
+            }
+
+            if (modelVerified)
+            {
+                break;
             }
         }
 
-        for (size_t i = 0; i < 16; ++i)
+        if (!modelVerified)
         {
-            if (!writeRegister(static_cast<uint8_t>(modelTableBase + 16 + i), model.modelTable[16 + i]))
+            return false;
+        }
+
+        bool lockVerified = false;
+        for (int attempt = 0; attempt < 3; ++attempt)
+        {
+            if (!writeRegister(Register::UnlockModel1, 0x0000)) return false;
+            if (!writeRegister(Register::UnlockModel2, 0x0000)) return false;
+
+            lockVerified = true;
+            for (size_t i = 0; i < 32; ++i)
             {
-                return false;
+                uint16_t val = 0;
+                if (!readRegister(static_cast<uint8_t>(modelTableBase + i), val) || val != 0x0000)
+                {
+                    lockVerified = false;
+                    break;
+                }
+            }
+
+            if (lockVerified)
+            {
+                break;
             }
         }
 
-        if (!writeRegister(Register::RCompSeg, model.rCompSeg)) return false;
+        if (!lockVerified)
+        {
+            return false;
+        }
 
-        if (!writeRegister(Register::UnlockModel1, 0x0000)) return false;
-        if (!writeRegister(Register::UnlockModel2, 0x0000)) return false;
-
-        if (!writeRegister(Register::RepCap, 0x0000)) return false;
+        if (!_writeAndVerify(Register::RepCap, 0x0000)) return false;
         vTaskDelay(pdMS_TO_TICKS(100));
         if (!writeRegister(Register::DesignCap, model.designCap)) return false;
 
@@ -397,7 +448,7 @@ namespace PowerFeather
             }
         }
 
-        if (!writeRegister(Register::LearnCfg, model.learnCfg)) return false;
+        if (!_writeAndVerify(Register::LearnCfg, model.learnCfg)) return false;
         if (!writeRegister(Register::RelaxCfg, model.relaxCfg)) return false;
         if (!writeRegister(Register::Config, model.config)) return false;
         if (!writeRegister(Register::MiscCfg, model.miscCfg)) return false;
@@ -456,13 +507,31 @@ namespace PowerFeather
 
         if (!writeRegister(Register::Config2, config2)) return false;
 
-        if (!writeRegister(Register::QRTable20, model.qrTable[2])) return false;
-        if (!writeRegister(Register::QRTable30, model.qrTable[3])) return false;
-        if (!writeRegister(Register::Cycles, 0x0000)) return false;
+        if (!_writeAndVerify(Register::QRTable20, model.qrTable[2])) return false;
+        if (!_writeAndVerify(Register::QRTable30, model.qrTable[3])) return false;
+        if (!_writeAndVerify(Register::Cycles, 0x0000)) return false;
 
         if (!writeRegister(Register::HibCfg, hibCfg)) return false;
 
         return _waitForDNRClear();
+    }
+
+    bool MAX17260::_writeAndVerify(Register address, uint16_t value)
+    {
+        for (int attempt = 0; attempt < 3; ++attempt)
+        {
+            if (!writeRegister(address, value))
+            {
+                return false;
+            }
+
+            uint16_t check = 0;
+            if (readRegister(address, check) && check == value)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     bool MAX17260::getEnabled(bool &enabled)

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -656,6 +656,17 @@ namespace PowerFeather
         return false;
     }
 
+    bool MAX17260::getUsingExternalTemperature(bool &external)
+    {
+        uint16_t config = 0;
+        if (readRegister(Register::Config, config))
+        {
+            external = (config & ConfigBit_TEx) != 0;
+            return true;
+        }
+        return false;
+    }
+
     bool MAX17260::setEnabled(bool enable)
     {
         if (enable)

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -704,7 +704,7 @@ namespace PowerFeather
         }
 
         uint8_t low = static_cast<uint8_t>(current & 0xFF);
-        uint8_t raw = 0xFF;
+        uint8_t raw = 0xFF; // Writing 0xFF (5100 mV) effectively disables the alarm.
         if (voltage != 0)
         {
             uint32_t value = (static_cast<uint32_t>(voltage) + 10u) / 20u;

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -202,20 +202,12 @@ namespace PowerFeather
         if (!writeRegister(Register::IChgTerm, _currentMaToRaw(config.data.capacity.terminationCurrentMa))) return false;
         if (!writeRegister(Register::VEmpty, VEmpty_Default)) return false;
 
-        uint16_t modelCfg = 0;
-        if (!readRegister(Register::ModelCfg, modelCfg))
-        {
-            return false;
-        }
-
-        modelCfg &= static_cast<uint16_t>(~ModelCfgMask_ModelID);
-        modelCfg &= static_cast<uint16_t>(~ModelCfgBit_VChg);
+        uint16_t modelCfg = ModelCfgBit_Refresh;
         modelCfg |= static_cast<uint16_t>((modelId & 0x7u) << 5);
         if (config.data.capacity.chargeVoltageMv > ModelCfgHighVoltageThresholdMv)
         {
             modelCfg |= ModelCfgBit_VChg;
         }
-        modelCfg |= ModelCfgBit_Refresh;
 
         if (!writeRegister(Register::ModelCfg, modelCfg))
         {

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -139,12 +139,34 @@ namespace PowerFeather
     bool MAX17260::probe()
     {
         uint16_t value = 0;
-        return readField(Fields::Status::POR, value);
+        return _verifyDeviceIdentity() && readField(Fields::Status::POR, value);
+    }
+
+    bool MAX17260::_verifyDeviceIdentity()
+    {
+        uint16_t devName = 0;
+        if (!readRegister(Register::DevName, devName))
+        {
+            return false;
+        }
+
+        if (devName != DevName_MAX17260)
+        {
+            ESP_LOGE(TAG, "Unexpected fuel-gauge DevName: 0x%04x (expected 0x%04x).", devName, DevName_MAX17260);
+            return false;
+        }
+
+        return true;
     }
 
     bool MAX17260::initImpl(const InitConfig &config)
     {
         if (!_initHardware())
+        {
+            return false;
+        }
+
+        if (!_verifyDeviceIdentity())
         {
             return false;
         }

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -182,7 +182,17 @@ namespace PowerFeather
                 }
                 model = &_profile;
             }
-            return loadModel(*model);
+
+            LearnedParameters restoreParameters = {};
+            const LearnedParameters *restoreParametersPtr = nullptr;
+            if (_hasRestoreLearnedParameters)
+            {
+                restoreParameters = _restoreLearnedParameters;
+                restoreParametersPtr = &restoreParameters;
+                _hasRestoreLearnedParameters = false;
+            }
+
+            return _loadModel(*model, restoreParametersPtr);
         }
 
         uint8_t modelId = ModelID_LiCoO2;
@@ -299,6 +309,11 @@ namespace PowerFeather
 
     bool MAX17260::loadModel(const Model &model)
     {
+        return _loadModel(model, nullptr);
+    }
+
+    bool MAX17260::_loadModel(const Model &model, const LearnedParameters *savedParameters)
+    {
         if (!_waitForDNRClear())
         {
             return false;
@@ -394,8 +409,20 @@ namespace PowerFeather
         vTaskDelay(pdMS_TO_TICKS(100));
         if (!writeRegister(Register::DesignCap, model.designCap)) return false;
 
-        const uint16_t fullCapNom = model.designCap;
-        const uint16_t fullCapRep = model.designCap;
+        uint16_t fullCapNom = model.designCap;
+        uint16_t fullCapRep = model.designCap;
+        uint16_t rComp0 = model.rComp0;
+        uint16_t tempCo = model.tempCo;
+        uint16_t cycles = 0x0000;
+
+        if (savedParameters)
+        {
+            fullCapRep = savedParameters->fullCapRep;
+            fullCapNom = savedParameters->fullCapNom;
+            rComp0 = savedParameters->rComp0;
+            tempCo = savedParameters->tempCo;
+            cycles = savedParameters->cycles;
+        }
 
         if (!writeRegister(Register::FullCapRep, fullCapRep)) return false;
 
@@ -446,8 +473,8 @@ namespace PowerFeather
 
         if (!writeRegister(Register::IChgTerm, model.ichgTerm)) return false;
         if (!writeRegister(Register::VEmpty, model.vEmpty)) return false;
-        if (!writeRegister(Register::RComp0, model.rComp0)) return false;
-        if (!writeRegister(Register::TempCo, model.tempCo)) return false;
+        if (!writeRegister(Register::RComp0, rComp0)) return false;
+        if (!writeRegister(Register::TempCo, tempCo)) return false;
 
         const uint8_t qrAddresses[4] = {
             static_cast<uint8_t>(Register::QRTable00),
@@ -524,7 +551,7 @@ namespace PowerFeather
 
         if (!_writeAndVerify(Register::QRTable20, model.qrTable[2])) return false;
         if (!_writeAndVerify(Register::QRTable30, model.qrTable[3])) return false;
-        if (!_writeAndVerify(Register::Cycles, 0x0000)) return false;
+        if (!_writeAndVerify(Register::Cycles, cycles)) return false;
 
         if (!writeRegister(Register::HibCfg, hibCfg)) return false;
 
@@ -656,6 +683,15 @@ namespace PowerFeather
         return false;
     }
 
+    bool MAX17260::getLearnedParameters(LearnedParameters &parameters)
+    {
+        return readRegister(Register::FullCapRep, parameters.fullCapRep) &&
+               readRegister(Register::FullCapNom, parameters.fullCapNom) &&
+               readRegister(Register::RComp0, parameters.rComp0) &&
+               readRegister(Register::TempCo, parameters.tempCo) &&
+               readRegister(Register::Cycles, parameters.cycles);
+    }
+
     bool MAX17260::getUsingExternalTemperature(bool &external)
     {
         uint16_t config = 0;
@@ -665,6 +701,17 @@ namespace PowerFeather
             return true;
         }
         return false;
+    }
+
+    void MAX17260::setRestoreLearnedParameters(const LearnedParameters &parameters)
+    {
+        _restoreLearnedParameters = parameters;
+        _hasRestoreLearnedParameters = true;
+    }
+
+    void MAX17260::clearRestoreLearnedParameters()
+    {
+        _hasRestoreLearnedParameters = false;
     }
 
     bool MAX17260::setEnabled(bool enable)

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -43,6 +43,15 @@ namespace PowerFeather
     class MAX17260 : public RegisterFuelGauge
     {
     public:
+        struct LearnedParameters
+        {
+            uint16_t fullCapRep{0};
+            uint16_t fullCapNom{0};
+            uint16_t rComp0{0};
+            uint16_t tempCo{0};
+            uint16_t cycles{0};
+        };
+
         struct Model
         {
             std::array<uint16_t, 32> modelTable{};
@@ -111,7 +120,10 @@ namespace PowerFeather
         bool getCycles(uint16_t &cycles) override;
         bool getSOH(uint8_t &percent) override;
         bool getInitialized(bool& state) override;
+        bool getLearnedParameters(LearnedParameters &parameters);
         bool getUsingExternalTemperature(bool &external);
+        void setRestoreLearnedParameters(const LearnedParameters &parameters);
+        void clearRestoreLearnedParameters();
         bool setEnabled(bool enable) override;
         bool setCellTemperature(float temperature) override;
         bool enableTSENSE(bool enableTsense1, bool enableTsense2) override;
@@ -250,6 +262,7 @@ namespace PowerFeather
         bool _initHardware();
         bool _waitForDNRClear();
         bool _waitForModelRefreshClear();
+        bool _loadModel(const Model &model, const LearnedParameters *savedParameters);
 
         bool _writeAndVerify(Register address, uint16_t value);
 
@@ -258,5 +271,7 @@ namespace PowerFeather
 
         Model _profile{};
         bool _hasProfile{false};
+        LearnedParameters _restoreLearnedParameters{};
+        bool _hasRestoreLearnedParameters{false};
     };
 }

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -204,7 +204,9 @@ namespace PowerFeather
 
         static constexpr uint16_t HibCfgBit_EnHib = 1u << 15;
         static constexpr uint16_t ModelCfgBit_Refresh = 1u << 15;
+        static constexpr uint16_t ModelCfgBit_VChg = 1u << 10;
         static constexpr uint16_t ModelCfgMask_ModelID = 0x7u << 5;
+        static constexpr uint16_t ModelCfgHighVoltageThresholdMv = 4275;
         static constexpr uint16_t ConfigBit_TSel = 1u << 15;
         static constexpr uint16_t ConfigBit_TEn = 1u << 9;
         static constexpr uint16_t ConfigBit_TEx = 1u << 8;

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -249,6 +249,8 @@ namespace PowerFeather
         bool _waitForDNRClear();
         bool _waitForModelRefreshClear();
 
+        bool _writeAndVerify(Register address, uint16_t value);
+
         static uint16_t _capacityMahToDesignCapRaw(uint16_t capacityMah);
         static uint16_t _currentMaToRaw(uint16_t currentMa);
 

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -244,6 +244,7 @@ namespace PowerFeather
             return writeRegister(static_cast<uint8_t>(address), value);
         }
         bool initImpl(const InitConfig &config) override;
+        bool _verifyDeviceIdentity();
         bool _initEZConfig(const InitConfig &config, uint8_t modelId);
         bool _initHardware();
         bool _waitForDNRClear();

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -111,6 +111,7 @@ namespace PowerFeather
         bool getCycles(uint16_t &cycles) override;
         bool getSOH(uint8_t &percent) override;
         bool getInitialized(bool& state) override;
+        bool getUsingExternalTemperature(bool &external);
         bool setEnabled(bool enable) override;
         bool setCellTemperature(float temperature) override;
         bool enableTSENSE(bool enableTsense1, bool enableTsense2) override;

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -343,6 +343,14 @@ namespace PowerFeather
         {
             RET_IF_FALSE(_i2c.start(), Result::Failure);
 
+            uint8_t pi = 0;
+            RET_IF_FALSE(getCharger().getPartInformation(pi), Result::Failure);
+            if (((pi >> 3) & 0x07) != BQ2562x::Charger_PN_BQ25622)
+            {
+                ESP_LOGE(TAG, "Unsupported charger part ID: 0x%02x (expected PN: 0x%02x)", pi, BQ2562x::Charger_PN_BQ25622);
+                return Result::NotSupported;
+            }
+
             bool wdOn = true;
             RET_IF_FALSE(getCharger().getWD(wdOn), Result::Failure);
 

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -116,6 +116,7 @@ namespace PowerFeather
         {
             config.data.capacity.capacityMah = _batteryCapacity;
             config.data.capacity.terminationCurrentMa = _terminationCurrent;
+            config.data.capacity.chargeVoltageMv = _chargeVoltageMv;
             switch (_batteryType)
             {
                 case BatteryType::Generic_3V7:
@@ -323,6 +324,7 @@ namespace PowerFeather
         {
             chargeVoltageMv = 3600;
         }
+        _chargeVoltageMv = chargeVoltageMv;
 
         // On first boot VSQT, through EN_SQT, is always enabled. On wake from deep sleep try and maintain held state.
         RET_IF_FALSE(_initInternalRTCPin(Pin::EN_SQT, RTC_GPIO_MODE_INPUT_OUTPUT), Result::Failure);
@@ -370,6 +372,9 @@ namespace PowerFeather
                 ESP_LOGD(TAG, "Charger IC already initialized.");
             }
 
+            // Enforce charge voltage target on every init path, including wake/re-init.
+            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
+
             // If battery capacity is not 0, initialize the fuel gauge. This can fail if during
             // startup no battery is connected, therefore failures are not checked here. Fuel guage
             // initialization attempts will be made later, during calls to member functions that
@@ -378,9 +383,6 @@ namespace PowerFeather
             {
                 _initFuelGauge();
             }
-
-            // Enforce charge voltage target on every init path, including wake/re-init.
-            RET_IF_FALSE(getCharger().setChargeVoltageLimit(chargeVoltageMv), Result::Failure);
         }
 
         // Initialize the rest of the RTC/digital pins managed by the SDK.

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -705,6 +705,15 @@ namespace PowerFeather
         float bias = 0;
         RET_IF_ERR(_udpateChargerADC());
         RET_IF_FALSE(getCharger().getTSBias(bias), Result::Failure);
+
+        // Check if bias is within plausible range for 103AT thermistor.
+        // Values outside [0.1, 0.8] likely indicate open/short circuit or missing thermistor.
+        if (bias < 0.10f || bias > 0.80f)
+        {
+            ESP_LOGD(TAG, "Battery thermistor bias %f is out of plausible range.", bias);
+            return Result::Failure;
+        }
+
         // Map bias to temperature given 103AT thermistor with fitted curve.
         celsius = (-1866.96172 * powf(bias, 4)) + (3169.31754 * powf(bias, 3)) - (1849.96775 * powf(bias, 2)) + (276.6656 * bias) + 81.98758;
         ESP_LOGD(TAG, "Measured battery temperature: %f °C.", celsius);

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -91,6 +91,18 @@ namespace PowerFeather
     static RTC_NOINIT_ATTR uint32_t first;
     static const uint32_t firstMagic = 0xdeadbeef;
 
+    // Charger state the user has committed via public setters. Placed in RTC
+    // slow memory so it survives deep sleep and can be re-applied to the chip
+    // in _reapplyChargerConfig. Valid iff first == firstMagic (warm boot).
+    struct PersistedChargerState
+    {
+        uint16_t chargingCurrentLimit;
+        uint16_t vindpm;
+        bool chargingEnabled;
+        bool tsEnabled;
+    };
+    static RTC_NOINIT_ATTR PersistedChargerState persistedChargerState;
+
     FuelGauge &Mainboard::getFuelGauge()
     {
         return _fuelGauge;
@@ -203,6 +215,8 @@ namespace PowerFeather
 
     Result Mainboard::_udpateChargerADC()
     {
+        RET_IF_ERR(_reapplyChargerConfig());
+
         uint32_t now = esp_timer_get_time() / 1000;
         // Since updating ADC values take a long time, only update it again after _chargerADCWaitTime has elapsed.
         if (_chargerADCTime == 0 || (now - _chargerADCTime) >= _chargerADCWaitTime)
@@ -220,6 +234,48 @@ namespace PowerFeather
             _chargerADCTime = now;
             ESP_LOGD(TAG, "Updated charger ADC.");
         }
+        return Result::Ok;
+    }
+
+    Result Mainboard::_reapplyChargerConfig()
+    {
+        bool wdOn = true;
+        RET_IF_FALSE(getCharger().getWD(wdOn), Result::Failure);
+
+        if (wdOn)
+        {
+            ESP_LOGW(TAG, "Charger watchdog enabled, re-applying configuration.");
+            RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
+            RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxChargingCurrent), Result::Failure);
+            RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
+            RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
+            RET_IF_FALSE(getCharger().setBATFETDelay(BQ2562x::BATFETDelay::Delay20ms), Result::Failure);
+            RET_IF_FALSE(getCharger().enableWVBUS(true), Result::Failure);
+            RET_IF_FALSE(getCharger().setTopOff(BQ2562x::TopOffTimer::Timer17Min), Result::Failure);
+            RET_IF_FALSE(getCharger().setIbatPk(BQ2562x::IbatPkLimit::Limit3A), Result::Failure);
+            RET_IF_FALSE(getCharger().setTH456(BQ2562x::TH456Setting::TH4_35_TH5_40_TH6_50), Result::Failure);
+            RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Precool, BQ2562x::TempIset::Ichg40), Result::Failure);
+            RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Prewarm, BQ2562x::TempIset::Ichg40), Result::Failure);
+            RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Cool, BQ2562x::TempIset::Ichg20), Result::Failure);
+            RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Warm, BQ2562x::TempIset::Ichg20), Result::Failure);
+            // Mask all interrupts first so POR-default unmasks don't leak through,
+            // then selectively re-enable only the ones the SDK actually uses.
+            RET_IF_FALSE(getCharger().enableInterrupts(false), Result::Failure);
+            if (_tsEnabled)
+            {
+                RET_IF_FALSE(getCharger().enableInterrupt(BQ2562x::Interrupt::TS, true), Result::Failure);
+            }
+            if (_batteryCapacity)
+            {
+                RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxIINDPMCurrent), Result::Failure);
+                RET_IF_FALSE(getCharger().setITERM(_terminationCurrent), Result::Failure);
+            }
+            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
+            RET_IF_FALSE(getCharger().setVINDPM(_vindpm), Result::Failure);
+            RET_IF_FALSE(getCharger().setWD(BQ2562x::WatchdogTimer::Disabled), Result::Failure);
+            RET_IF_FALSE(getCharger().enableCharging(_chargingEnabled), Result::Failure);
+        }
+
         return Result::Ok;
     }
 
@@ -304,6 +360,31 @@ namespace PowerFeather
         _batteryCapacity = capacity;
         _batteryType = type;
         _usesProfile = useProfile;
+        _chargingEnabled = false;
+        _chargingCurrentLimit = _defaultMaxChargingCurrent;
+        _tsEnabled = false;
+        _vindpm = _minSupplyMaintainVoltage;
+        if (!_isFirst())
+        {
+            // Warm boot: the chip may have retained the previous session's config
+            // (wdOn == false) or may have POR'd (wdOn == true). Either way,
+            // _reapplyChargerConfig should restore what the user last set, not
+            // reset to defaults — so rehydrate from RTC-persisted state.
+            _chargingEnabled = persistedChargerState.chargingEnabled;
+            _chargingCurrentLimit = persistedChargerState.chargingCurrentLimit;
+            _tsEnabled = persistedChargerState.tsEnabled;
+            _vindpm = persistedChargerState.vindpm;
+        }
+        else
+        {
+            // Cold boot: RTC_NOINIT_ATTR leaves persistedChargerState undefined.
+            // Seed it with the defaults above so that a warm boot prior to any
+            // setter call rehydrates known-good values instead of RTC garbage.
+            persistedChargerState.chargingEnabled = _chargingEnabled;
+            persistedChargerState.chargingCurrentLimit = _chargingCurrentLimit;
+            persistedChargerState.tsEnabled = _tsEnabled;
+            persistedChargerState.vindpm = _vindpm;
+        }
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
         _fuelGaugeUsingExternalTemp = false;
 #endif
@@ -352,40 +433,17 @@ namespace PowerFeather
                 return Result::Failure;
             }
 
-            bool wdOn = true;
-            RET_IF_FALSE(getCharger().getWD(wdOn), Result::Failure);
+            // _reapplyChargerConfig is gated on the charger watchdog (POR indicator).
+            // On wdOn == true (first init, or chip POR since last init), it applies the
+            // full configuration using the software state set above — which on a warm
+            // boot is the user's previous-session values rehydrated from RTC, not the
+            // hardcoded defaults. On wdOn == false (chip retained state), it's a no-op
+            // and the redundant setChargeVoltageLimit below is the belt-and-braces write.
+            RET_IF_ERR(_reapplyChargerConfig());
 
-            if (wdOn) // watchdog enabled means that the initiatialization was not done previously
-            {
-                RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
-                RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxChargingCurrent), Result::Failure);
-                RET_IF_FALSE(getCharger().enableTS(false), Result::Failure);
-                RET_IF_FALSE(getCharger().setChargeCurrentLimit(_defaultMaxChargingCurrent), Result::Failure);
-                RET_IF_FALSE(getCharger().setBATFETDelay(BQ2562x::BATFETDelay::Delay20ms), Result::Failure);
-                RET_IF_FALSE(getCharger().enableWVBUS(true), Result::Failure);
-                RET_IF_FALSE(getCharger().setTopOff(BQ2562x::TopOffTimer::Timer17Min), Result::Failure);
-                RET_IF_FALSE(getCharger().setIbatPk(BQ2562x::IbatPkLimit::Limit3A), Result::Failure);
-                RET_IF_FALSE(getCharger().setTH456(BQ2562x::TH456Setting::TH4_35_TH5_40_TH6_50), Result::Failure);
-                RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Precool, BQ2562x::TempIset::Ichg40), Result::Failure);
-                RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Prewarm, BQ2562x::TempIset::Ichg40), Result::Failure);
-                RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Cool, BQ2562x::TempIset::Ichg20), Result::Failure);
-                RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Warm, BQ2562x::TempIset::Ichg20), Result::Failure);
-                RET_IF_FALSE(getCharger().enableInterrupts(false), Result::Failure);
-                if (_batteryCapacity)
-                {
-                RET_IF_FALSE(getCharger().setITERM(_terminationCurrent), Result::Failure);
-                }
-                // Disable the charger watchdog to keep the charger in host mode and to
-                // keep some registers from resetting to their POR values.
-                RET_IF_FALSE(getCharger().setWD(BQ2562x::WatchdogTimer::Disabled), Result::Failure);
-                ESP_LOGD(TAG, "Charger IC initialized.");
-            }
-            else
-            {
-                ESP_LOGD(TAG, "Charger IC already initialized.");
-            }
-
-            // Enforce charge voltage target on every init path, including wake/re-init.
+            // Enforce charge voltage target on every init path, including the wdOn==false
+            // path (chip retained state across sleep but we still want to rewrite VREG
+            // in case the BatteryType chemistry selection changed since last session).
             RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
 
             // If battery capacity is not 0, initialize the fuel gauge. This can fail if during
@@ -446,7 +504,21 @@ namespace PowerFeather
         // On V2, power-management I2C remains usable even with VSQT disabled.
         ESP_LOGD(TAG, "VSQT set to: %d.", enable);
 #else
-        RET_IF_FALSE(enable ? (_sqtEnabled || _i2c.start()) : !_sqtEnabled || _i2c.end(), Result::Failure);
+        if (enable && !_sqtEnabled)
+        {
+            RET_IF_FALSE(_i2c.start(), Result::Failure);
+            RET_IF_ERR(_reapplyChargerConfig());
+            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
+            _chargerADCTime = 0;
+            if (_batteryCapacity)
+            {
+                _initFuelGauge();
+            }
+        }
+        else if (!enable && _sqtEnabled)
+        {
+            RET_IF_FALSE(_i2c.end(), Result::Failure);
+        }
         _sqtEnabled = enable;
         ESP_LOGD(TAG, "VSQT set to: %d.", _sqtEnabled);
 #endif
@@ -500,7 +572,10 @@ namespace PowerFeather
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_FALSE(voltage >= _minSupplyMaintainVoltage && voltage <= BQ2562x::MaxVINDPMVoltage, Result::InvalidArg);
+        RET_IF_ERR(_reapplyChargerConfig());
         RET_IF_FALSE(getCharger().setVINDPM(voltage), Result::Failure);
+        _vindpm = voltage;
+        persistedChargerState.vindpm = voltage;
         ESP_LOGD(TAG, "Maintain supply voltage set to: %d mV.", voltage);
         return Result::Ok;
     }
@@ -550,7 +625,10 @@ namespace PowerFeather
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
+        RET_IF_ERR(_reapplyChargerConfig());
         RET_IF_FALSE(getCharger().enableCharging(enable), Result::Failure);
+        _chargingEnabled = enable;
+        persistedChargerState.chargingEnabled = enable;
         ESP_LOGD(TAG, "Charging set to: %d.", enable);
         return Result::Ok;
     }
@@ -561,8 +639,11 @@ namespace PowerFeather
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
+        RET_IF_ERR(_reapplyChargerConfig());
         RET_IF_FALSE(current >= BQ2562x::MinChargingCurrent && current <= BQ2562x::MaxChargingCurrent, Result::InvalidArg);
         RET_IF_FALSE(getCharger().setChargeCurrentLimit(current), Result::Failure);
+        _chargingCurrentLimit = current;
+        persistedChargerState.chargingCurrentLimit = current;
         ESP_LOGD(TAG, "Max charging current set to: %d mA.", current);
         return Result::Ok;
     }
@@ -573,8 +654,11 @@ namespace PowerFeather
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
+        RET_IF_ERR(_reapplyChargerConfig());
         RET_IF_FALSE(getCharger().enableTS(enable), Result::Failure);
         RET_IF_FALSE(getCharger().enableInterrupt(BQ2562x::Interrupt::TS, enable), Result::Failure);
+        _tsEnabled = enable;
+        persistedChargerState.tsEnabled = enable;
         ESP_LOGD(TAG, "Temperature sense set to: %d.", enable);
         return Result::Ok;
     }

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -345,10 +345,11 @@ namespace PowerFeather
 
             uint8_t pi = 0;
             RET_IF_FALSE(getCharger().getPartInformation(pi), Result::Failure);
-            if (((pi >> 3) & 0x07) != BQ2562x::Charger_PN_BQ25622)
+            uint8_t pn = (pi >> 3) & 0x07;
+            if (pn != BQ2562x::Charger_PN_BQ25622 && pn != BQ2562x::Charger_PN_BQ25628)
             {
-                ESP_LOGE(TAG, "Unsupported charger part ID: 0x%02x (expected PN: 0x%02x)", pi, BQ2562x::Charger_PN_BQ25622);
-                return Result::NotSupported;
+                ESP_LOGE(TAG, "Unsupported charger part ID: 0x%02x (expected PN: 0x%02x or 0x%02x)", pi, BQ2562x::Charger_PN_BQ25622, BQ2562x::Charger_PN_BQ25628);
+                return Result::Failure;
             }
 
             bool wdOn = true;

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -547,6 +547,7 @@ namespace PowerFeather
                                                                                    _terminationCurrent,
                                                                                    _chargeVoltageMv,
                                                                                    _profileHash);
+        const bool chargingSupported = (_batteryCapacity == 0) || (_batteryCapacity >= _minChargeableBatteryCapacity);
 
         _chargingEnabled = false;
         _chargingCurrentLimit = _defaultMaxChargingCurrent;
@@ -597,6 +598,15 @@ namespace PowerFeather
             _lastFuelGaugeInitSignature = {};
             _hasFuelGaugeInitSignature = false;
         }
+
+        if (_batteryCapacity && !chargingSupported)
+        {
+            // Tiny V2 packs are supported for monitoring only. Reset any
+            // retained charging state so init() cannot inherit an unsafe
+            // charge-enable/current policy from a previous session.
+            _chargingEnabled = false;
+            _chargingCurrentLimit = _defaultMaxChargingCurrent;
+        }
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
         _fuelGaugeUsingExternalTemp = false;
 #endif
@@ -639,6 +649,12 @@ namespace PowerFeather
             // path (chip retained state across sleep but we still want to rewrite VREG
             // in case the BatteryType chemistry selection changed since last session).
             RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
+
+            if (_batteryCapacity && !chargingSupported)
+            {
+                RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
+                RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
+            }
 
             if (!_isFirst() && !chargerSignatureMatch)
             {
@@ -845,6 +861,7 @@ namespace PowerFeather
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
+        RET_IF_FALSE(!enable || _batteryCapacity >= _minChargeableBatteryCapacity, Result::InvalidState);
         RET_IF_ERR(_reapplyChargerConfig());
         RET_IF_FALSE(getCharger().enableCharging(enable), Result::Failure);
         _chargingEnabled = enable;
@@ -859,6 +876,7 @@ namespace PowerFeather
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
+        RET_IF_FALSE(_batteryCapacity >= _minChargeableBatteryCapacity, Result::InvalidState);
         RET_IF_ERR(_reapplyChargerConfig());
         RET_IF_FALSE(current >= BQ2562x::MinChargingCurrent && current <= BQ2562x::MaxChargingCurrent, Result::InvalidArg);
         RET_IF_FALSE(getCharger().setChargeCurrentLimit(current), Result::Failure);

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -209,7 +209,13 @@ namespace PowerFeather
         {
             bool done = false;
             RET_IF_FALSE(getCharger().setupADC(true, BQ2562x::ADCRate::Oneshot, BQ2562x::ADCSampling::Bits_10), Result::Failure);
+
+            // Release lock during long ADC wait to preserve parallel-task responsiveness,
+            // then block indefinitely on relock to guarantee the caller's RAII contract is honored.
+            _mutex.unlock();
             vTaskDelay(pdMS_TO_TICKS(_chargerADCWaitTime));
+            _mutex.lockBlocking();
+
             RET_IF_FALSE(getCharger().getADCDone(done) && done, Result::Failure);
             _chargerADCTime = now;
             ESP_LOGD(TAG, "Updated charger ADC.");

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -54,6 +54,18 @@ namespace PowerFeather
 
     namespace
     {
+        static uint32_t fnv1aHash(const void *data, size_t size)
+        {
+            const uint8_t *bytes = static_cast<const uint8_t *>(data);
+            uint32_t hash = 2166136261u;
+            for (size_t i = 0; i < size; ++i)
+            {
+                hash ^= bytes[i];
+                hash *= 16777619u;
+            }
+            return hash;
+        }
+
         template <typename Gauge>
         struct FuelGaugeProfileHelper
         {
@@ -103,6 +115,17 @@ namespace PowerFeather
     };
     static RTC_NOINIT_ATTR PersistedChargerState persistedChargerState;
 
+    struct PersistedFuelGaugeInitSignature
+    {
+        uint8_t source;
+        uint16_t capacityMah;
+        uint16_t terminationCurrentMa;
+        uint16_t chargeVoltageMv;
+        uint32_t profileHash;
+        bool hasSignature;
+    };
+    static RTC_NOINIT_ATTR PersistedFuelGaugeInitSignature persistedFuelGaugeInitSignature;
+
     FuelGauge &Mainboard::getFuelGauge()
     {
         return _fuelGauge;
@@ -119,17 +142,23 @@ namespace PowerFeather
     {
         FuelGauge &gauge = getFuelGauge();
         FuelGauge::InitConfig config;
+        FuelGaugeInitSignature signature;
 
         if (_usesProfile)
         {
             config.source = FuelGauge::InitSource::Profile_Max17260;
             config.data.profile.model = nullptr;
+            signature.source = config.source;
+            signature.profileHash = _profileHash;
         }
         else
         {
             config.data.capacity.capacityMah = _batteryCapacity;
             config.data.capacity.terminationCurrentMa = _terminationCurrent;
             config.data.capacity.chargeVoltageMv = _chargeVoltageMv;
+            signature.capacityMah = _batteryCapacity;
+            signature.terminationCurrentMa = _terminationCurrent;
+            signature.chargeVoltageMv = _chargeVoltageMv;
             switch (_batteryType)
             {
                 case BatteryType::Generic_3V7:
@@ -145,13 +174,28 @@ namespace PowerFeather
                     config.source = FuelGauge::InitSource::Generic_LFP;
                     break;
             }
+            signature.source = config.source;
         }
 
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
         config.tsenseEnabled = !_fuelGaugeUsingExternalTemp;
 #endif
 
-        RET_IF_FALSE(gauge.init(config), Result::Failure);
+        bool forceReinit = _hasFuelGaugeInitSignature &&
+                           (signature.source != _lastFuelGaugeInitSignature.source ||
+                            signature.capacityMah != _lastFuelGaugeInitSignature.capacityMah ||
+                            signature.terminationCurrentMa != _lastFuelGaugeInitSignature.terminationCurrentMa ||
+                            signature.chargeVoltageMv != _lastFuelGaugeInitSignature.chargeVoltageMv ||
+                            signature.profileHash != _lastFuelGaugeInitSignature.profileHash);
+        RET_IF_FALSE(gauge.init(config, forceReinit), Result::Failure);
+        _lastFuelGaugeInitSignature = signature;
+        _hasFuelGaugeInitSignature = true;
+        persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(signature.source);
+        persistedFuelGaugeInitSignature.capacityMah = signature.capacityMah;
+        persistedFuelGaugeInitSignature.terminationCurrentMa = signature.terminationCurrentMa;
+        persistedFuelGaugeInitSignature.chargeVoltageMv = signature.chargeVoltageMv;
+        persistedFuelGaugeInitSignature.profileHash = signature.profileHash;
+        persistedFuelGaugeInitSignature.hasSignature = true;
         ESP_LOGD(TAG, "Fuel gauge init complete (%s).", gauge.getName());
 
         return Result::Ok;
@@ -360,6 +404,7 @@ namespace PowerFeather
         _batteryCapacity = capacity;
         _batteryType = type;
         _usesProfile = useProfile;
+        _profileHash = useProfile ? fnv1aHash(profile, sizeof(*profile)) : 0;
         _chargingEnabled = false;
         _chargingCurrentLimit = _defaultMaxChargingCurrent;
         _tsEnabled = false;
@@ -374,6 +419,12 @@ namespace PowerFeather
             _chargingCurrentLimit = persistedChargerState.chargingCurrentLimit;
             _tsEnabled = persistedChargerState.tsEnabled;
             _vindpm = persistedChargerState.vindpm;
+            _lastFuelGaugeInitSignature.source = static_cast<FuelGauge::InitSource>(persistedFuelGaugeInitSignature.source);
+            _lastFuelGaugeInitSignature.capacityMah = persistedFuelGaugeInitSignature.capacityMah;
+            _lastFuelGaugeInitSignature.terminationCurrentMa = persistedFuelGaugeInitSignature.terminationCurrentMa;
+            _lastFuelGaugeInitSignature.chargeVoltageMv = persistedFuelGaugeInitSignature.chargeVoltageMv;
+            _lastFuelGaugeInitSignature.profileHash = persistedFuelGaugeInitSignature.profileHash;
+            _hasFuelGaugeInitSignature = persistedFuelGaugeInitSignature.hasSignature;
         }
         else
         {
@@ -384,6 +435,14 @@ namespace PowerFeather
             persistedChargerState.chargingCurrentLimit = _chargingCurrentLimit;
             persistedChargerState.tsEnabled = _tsEnabled;
             persistedChargerState.vindpm = _vindpm;
+            persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(FuelGauge::InitSource::Generic_3V7);
+            persistedFuelGaugeInitSignature.capacityMah = 0;
+            persistedFuelGaugeInitSignature.terminationCurrentMa = 0;
+            persistedFuelGaugeInitSignature.chargeVoltageMv = 0;
+            persistedFuelGaugeInitSignature.profileHash = 0;
+            persistedFuelGaugeInitSignature.hasSignature = false;
+            _lastFuelGaugeInitSignature = {};
+            _hasFuelGaugeInitSignature = false;
         }
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
         _fuelGaugeUsingExternalTemp = false;

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -66,6 +66,60 @@ namespace PowerFeather
             return hash;
         }
 
+        struct ChargerInitSignature
+        {
+            uint8_t source;
+            uint16_t capacityMah;
+            uint16_t terminationCurrentMa;
+            uint16_t chargeVoltageMv;
+            uint32_t profileHash;
+            bool batteryExpected;
+        };
+
+        static ChargerInitSignature makeChargerInitSignature(Mainboard::BatteryType type,
+                                                             bool useProfile,
+                                                             uint16_t capacityMah,
+                                                             uint16_t terminationCurrentMa,
+                                                             uint16_t chargeVoltageMv,
+                                                             uint32_t profileHash)
+        {
+            ChargerInitSignature signature = {};
+            signature.batteryExpected = (capacityMah != 0);
+            signature.capacityMah = capacityMah;
+
+            if (useProfile)
+            {
+                signature.source = static_cast<uint8_t>(FuelGauge::InitSource::Profile_Max17260);
+                signature.profileHash = profileHash;
+            }
+            else
+            {
+                switch (type)
+                {
+                    case Mainboard::BatteryType::Generic_3V7:
+                        signature.source = static_cast<uint8_t>(FuelGauge::InitSource::Generic_3V7);
+                        break;
+                    case Mainboard::BatteryType::ICR18650_26H:
+                        signature.source = static_cast<uint8_t>(FuelGauge::InitSource::ICR18650_26H);
+                        break;
+                    case Mainboard::BatteryType::UR18650ZY:
+                        signature.source = static_cast<uint8_t>(FuelGauge::InitSource::UR18650ZY);
+                        break;
+                    case Mainboard::BatteryType::Generic_LFP:
+                        signature.source = static_cast<uint8_t>(FuelGauge::InitSource::Generic_LFP);
+                        break;
+                }
+            }
+
+            if (signature.batteryExpected)
+            {
+                signature.terminationCurrentMa = terminationCurrentMa;
+                signature.chargeVoltageMv = chargeVoltageMv;
+            }
+
+            return signature;
+        }
+
         template <typename Gauge>
         struct FuelGaugeProfileHelper
         {
@@ -148,6 +202,18 @@ namespace PowerFeather
         bool tsEnabled;
     };
     static RTC_NOINIT_ATTR PersistedChargerState persistedChargerState;
+
+    struct PersistedChargerInitSignature
+    {
+        uint8_t source;
+        uint16_t capacityMah;
+        uint16_t terminationCurrentMa;
+        uint16_t chargeVoltageMv;
+        uint32_t profileHash;
+        bool batteryExpected;
+        bool hasSignature;
+    };
+    static RTC_NOINIT_ATTR PersistedChargerInitSignature persistedChargerInitSignature;
 
     struct PersistedFuelGaugeInitSignature
     {
@@ -446,53 +512,7 @@ namespace PowerFeather
         _batteryType = type;
         _usesProfile = useProfile;
         _profileHash = useProfile ? fnv1aHash(profile, sizeof(*profile)) : 0;
-        _chargingEnabled = false;
-        _chargingCurrentLimit = _defaultMaxChargingCurrent;
-        _tsEnabled = false;
-        _vindpm = _minSupplyMaintainVoltage;
-        if (!_isFirst())
-        {
-            // Warm boot: the chip may have retained the previous session's config
-            // (wdOn == false) or may have POR'd (wdOn == true). Either way,
-            // _reapplyChargerConfig should restore what the user last set, not
-            // reset to defaults — so rehydrate from RTC-persisted state.
-            _chargingEnabled = persistedChargerState.chargingEnabled;
-            _chargingCurrentLimit = persistedChargerState.chargingCurrentLimit;
-            _tsEnabled = persistedChargerState.tsEnabled;
-            _vindpm = persistedChargerState.vindpm;
-            _lastFuelGaugeInitSignature.source = static_cast<FuelGauge::InitSource>(persistedFuelGaugeInitSignature.source);
-            _lastFuelGaugeInitSignature.capacityMah = persistedFuelGaugeInitSignature.capacityMah;
-            _lastFuelGaugeInitSignature.terminationCurrentMa = persistedFuelGaugeInitSignature.terminationCurrentMa;
-            _lastFuelGaugeInitSignature.chargeVoltageMv = persistedFuelGaugeInitSignature.chargeVoltageMv;
-            _lastFuelGaugeInitSignature.profileHash = persistedFuelGaugeInitSignature.profileHash;
-            _hasFuelGaugeInitSignature = persistedFuelGaugeInitSignature.hasSignature;
-        }
-        else
-        {
-            // Cold boot: RTC_NOINIT_ATTR leaves persistedChargerState undefined.
-            // Seed it with the defaults above so that a warm boot prior to any
-            // setter call rehydrates known-good values instead of RTC garbage.
-            persistedChargerState.chargingEnabled = _chargingEnabled;
-            persistedChargerState.chargingCurrentLimit = _chargingCurrentLimit;
-            persistedChargerState.tsEnabled = _tsEnabled;
-            persistedChargerState.vindpm = _vindpm;
-            persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(FuelGauge::InitSource::Generic_3V7);
-            persistedFuelGaugeInitSignature.capacityMah = 0;
-            persistedFuelGaugeInitSignature.terminationCurrentMa = 0;
-            persistedFuelGaugeInitSignature.chargeVoltageMv = 0;
-            persistedFuelGaugeInitSignature.profileHash = 0;
-            persistedFuelGaugeInitSignature.hasSignature = false;
-            _lastFuelGaugeInitSignature = {};
-            _hasFuelGaugeInitSignature = false;
-        }
-#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
-        _fuelGaugeUsingExternalTemp = false;
-#endif
-        ESP_LOGD(TAG, "Battery capacity and type set to %d mAh, %d.", static_cast<int>(_batteryCapacity), static_cast<int>(_batteryType));
-        if (useProfile)
-        {
-            FuelGaugeProfileHelper<FuelGaugeImpl>::setProfile(_fuelGauge, profile);
-        }
+
         // Set termination current to C / 10, or within limits of the IC.
         uint16_t minCurrent = BQ2562x::MinITERMCurrent;
         uint16_t maxCurrent = BQ2562x::MaxITERMCurrent;
@@ -511,6 +531,70 @@ namespace PowerFeather
         }
         _chargeVoltageMv = chargeVoltageMv;
 
+        ChargerInitSignature currentChargerInitSignature = makeChargerInitSignature(_batteryType,
+                                                                                   _usesProfile,
+                                                                                   _batteryCapacity,
+                                                                                   _terminationCurrent,
+                                                                                   _chargeVoltageMv,
+                                                                                   _profileHash);
+
+        _chargingEnabled = false;
+        _chargingCurrentLimit = _defaultMaxChargingCurrent;
+        _tsEnabled = false;
+        _vindpm = _minSupplyMaintainVoltage;
+        bool chargerSignatureMatch = false;
+        if (!_isFirst())
+        {
+            chargerSignatureMatch = persistedChargerInitSignature.hasSignature &&
+                                    persistedChargerInitSignature.source == currentChargerInitSignature.source &&
+                                    persistedChargerInitSignature.capacityMah == currentChargerInitSignature.capacityMah &&
+                                    persistedChargerInitSignature.terminationCurrentMa == currentChargerInitSignature.terminationCurrentMa &&
+                                    persistedChargerInitSignature.chargeVoltageMv == currentChargerInitSignature.chargeVoltageMv &&
+                                    persistedChargerInitSignature.profileHash == currentChargerInitSignature.profileHash &&
+                                    persistedChargerInitSignature.batteryExpected == currentChargerInitSignature.batteryExpected;
+            if (chargerSignatureMatch)
+            {
+                // Warm boot with unchanged battery/profile inputs: retain the
+                // user-committed charger state across RTC-retaining resets.
+                _chargingEnabled = persistedChargerState.chargingEnabled;
+                _chargingCurrentLimit = persistedChargerState.chargingCurrentLimit;
+                _tsEnabled = persistedChargerState.tsEnabled;
+                _vindpm = persistedChargerState.vindpm;
+            }
+            _lastFuelGaugeInitSignature.source = static_cast<FuelGauge::InitSource>(persistedFuelGaugeInitSignature.source);
+            _lastFuelGaugeInitSignature.capacityMah = persistedFuelGaugeInitSignature.capacityMah;
+            _lastFuelGaugeInitSignature.terminationCurrentMa = persistedFuelGaugeInitSignature.terminationCurrentMa;
+            _lastFuelGaugeInitSignature.chargeVoltageMv = persistedFuelGaugeInitSignature.chargeVoltageMv;
+            _lastFuelGaugeInitSignature.profileHash = persistedFuelGaugeInitSignature.profileHash;
+            _hasFuelGaugeInitSignature = persistedFuelGaugeInitSignature.hasSignature;
+        }
+        else
+        {
+            // Cold boot: RTC_NOINIT_ATTR leaves persistedChargerState undefined.
+            // Seed it with the defaults above so that a warm boot prior to any
+            // setter call rehydrates known-good values instead of RTC garbage.
+            persistedChargerState.chargingEnabled = _chargingEnabled;
+            persistedChargerState.chargingCurrentLimit = _chargingCurrentLimit;
+            persistedChargerState.tsEnabled = _tsEnabled;
+            persistedChargerState.vindpm = _vindpm;
+            persistedChargerInitSignature.hasSignature = false;
+            persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(FuelGauge::InitSource::Generic_3V7);
+            persistedFuelGaugeInitSignature.capacityMah = 0;
+            persistedFuelGaugeInitSignature.terminationCurrentMa = 0;
+            persistedFuelGaugeInitSignature.chargeVoltageMv = 0;
+            persistedFuelGaugeInitSignature.profileHash = 0;
+            persistedFuelGaugeInitSignature.hasSignature = false;
+            _lastFuelGaugeInitSignature = {};
+            _hasFuelGaugeInitSignature = false;
+        }
+#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
+        _fuelGaugeUsingExternalTemp = false;
+#endif
+        ESP_LOGD(TAG, "Battery capacity and type set to %d mAh, %d.", static_cast<int>(_batteryCapacity), static_cast<int>(_batteryType));
+        if (useProfile)
+        {
+            FuelGaugeProfileHelper<FuelGaugeImpl>::setProfile(_fuelGauge, profile);
+        }
         // On first boot VSQT, through EN_SQT, is always enabled. On wake from deep sleep try and maintain held state.
         RET_IF_FALSE(_initInternalRTCPin(Pin::EN_SQT, RTC_GPIO_MODE_INPUT_OUTPUT), Result::Failure);
         bool sqtEnabled = _isFirst() ? true : rtc_gpio_get_level(Pin::EN_SQT);
@@ -546,6 +630,19 @@ namespace PowerFeather
             // in case the BatteryType chemistry selection changed since last session).
             RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
 
+            if (!_isFirst() && !chargerSignatureMatch)
+            {
+                // On a warm boot with changed battery/profile inputs, the
+                // charger may have retained the previous session's live state
+                // even though software intentionally reset to safe defaults.
+                // Push those defaults into the retained hardware as well.
+                RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
+                RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
+                RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
+                RET_IF_FALSE(getCharger().enableInterrupt(BQ2562x::Interrupt::TS, false), Result::Failure);
+                RET_IF_FALSE(getCharger().setVINDPM(_vindpm), Result::Failure);
+            }
+
             // If battery capacity is not 0, initialize the fuel gauge. This can fail if during
             // startup no battery is connected, therefore failures are not checked here. Fuel guage
             // initialization attempts will be made later, during calls to member functions that
@@ -568,6 +665,18 @@ namespace PowerFeather
         ESP_LOGD(TAG, "3V3 detected as %d during initialization.", _3V3Enabled);
 
         RET_IF_FALSE(_initInternalDigitalPin(Pin::PG, GPIO_MODE_INPUT), Result::Failure);
+
+        persistedChargerState.chargingEnabled = _chargingEnabled;
+        persistedChargerState.chargingCurrentLimit = _chargingCurrentLimit;
+        persistedChargerState.tsEnabled = _tsEnabled;
+        persistedChargerState.vindpm = _vindpm;
+        persistedChargerInitSignature.source = currentChargerInitSignature.source;
+        persistedChargerInitSignature.capacityMah = currentChargerInitSignature.capacityMah;
+        persistedChargerInitSignature.terminationCurrentMa = currentChargerInitSignature.terminationCurrentMa;
+        persistedChargerInitSignature.chargeVoltageMv = currentChargerInitSignature.chargeVoltageMv;
+        persistedChargerInitSignature.profileHash = currentChargerInitSignature.profileHash;
+        persistedChargerInitSignature.batteryExpected = currentChargerInitSignature.batteryExpected;
+        persistedChargerInitSignature.hasSignature = true;
 
         first = firstMagic;
         _initDone = true;

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -40,6 +40,7 @@
 
 #include <soc/reset_reasons.h>
 #include <esp_log.h>
+#include <esp_timer.h>
 
 #include "Mainboard.h"
 
@@ -205,7 +206,7 @@ namespace PowerFeather
 
     Result Mainboard::_udpateChargerADC()
     {
-        uint32_t now = 0;
+        uint32_t now = esp_timer_get_time() / 1000;
         // Since updating ADC values take a long time, only update it again after _chargerADCWaitTime has elapsed.
         if (_chargerADCTime == 0 || (now - _chargerADCTime) >= _chargerADCWaitTime)
         {

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -135,14 +135,11 @@ namespace PowerFeather
             }
         }
 
-        RET_IF_FALSE(gauge.init(config), Result::Failure);
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
-        // Default to IC-managed temperature until the host starts providing external temperature updates.
-        if (!_fuelGaugeUsingExternalTemp)
-        {
-            RET_IF_FALSE(gauge.enableTSENSE(true, false), Result::Failure);
-        }
+        config.tsenseEnabled = !_fuelGaugeUsingExternalTemp;
 #endif
+
+        RET_IF_FALSE(gauge.init(config), Result::Failure);
         ESP_LOGD(TAG, "Fuel gauge init complete (%s).", gauge.getName());
 
         return Result::Ok;

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -189,7 +189,9 @@ namespace PowerFeather
     #define TRY_LOCK(m)                 Mutex::Lock m##Lock(m); RET_IF_FALSE(m##Lock.isLocked(), Result::LockFailed);
 
     static RTC_NOINIT_ATTR uint32_t first;
+    static RTC_NOINIT_ATTR uint32_t rtcStateVersion;
     static const uint32_t firstMagic = 0xdeadbeef;
+    static const uint32_t rtcStateVersionMagic = 0x20260423;
 
     // Charger state the user has committed via public setters. Placed in RTC
     // slow memory so it survives deep sleep and can be re-applied to the chip
@@ -244,12 +246,6 @@ namespace PowerFeather
         FuelGauge::InitConfig config;
         FuelGaugeInitSignature signature;
 
-#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
-        RET_IF_FALSE(FuelGaugeTempModeHelper<FuelGaugeImpl>::syncUsingExternalTemp(
-                         static_cast<FuelGaugeImpl &>(gauge), _fuelGaugeUsingExternalTemp),
-                     Result::Failure);
-#endif
-
         if (_usesProfile)
         {
             config.source = FuelGauge::InitSource::Profile_Max17260;
@@ -283,16 +279,29 @@ namespace PowerFeather
             signature.source = config.source;
         }
 
-#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
-        config.tsenseEnabled = !_fuelGaugeUsingExternalTemp;
-#endif
-
         bool forceReinit = _hasFuelGaugeInitSignature &&
                            (signature.source != _lastFuelGaugeInitSignature.source ||
                             signature.capacityMah != _lastFuelGaugeInitSignature.capacityMah ||
                             signature.terminationCurrentMa != _lastFuelGaugeInitSignature.terminationCurrentMa ||
                             signature.chargeVoltageMv != _lastFuelGaugeInitSignature.chargeVoltageMv ||
                             signature.profileHash != _lastFuelGaugeInitSignature.profileHash);
+#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
+        if (_hasFuelGaugeInitSignature && !forceReinit)
+        {
+            RET_IF_FALSE(FuelGaugeTempModeHelper<FuelGaugeImpl>::syncUsingExternalTemp(
+                             static_cast<FuelGaugeImpl &>(gauge), _fuelGaugeUsingExternalTemp),
+                         Result::Failure);
+        }
+        else
+        {
+            // An explicit gauge reinit, or any init without a trusted prior
+            // signature, should return to the documented default internal-
+            // temperature mode. Preserve external-temperature mode only on the
+            // retained fast path where the battery/profile inputs still match.
+            _fuelGaugeUsingExternalTemp = false;
+        }
+        config.tsenseEnabled = !_fuelGaugeUsingExternalTemp;
+#endif
         RET_IF_FALSE(gauge.init(config, forceReinit), Result::Failure);
         _lastFuelGaugeInitSignature = signature;
         _hasFuelGaugeInitSignature = true;
@@ -309,8 +318,9 @@ namespace PowerFeather
 
     bool Mainboard::_isFirst()
     {
-        // If the RTC is domain is shutdown, consider next boot as first boot.
-        bool isFirst = (first != firstMagic);
+        // If the RTC domain is shut down, or retained RTC state was produced by
+        // an older firmware layout, consider the next boot as first boot.
+        bool isFirst = (first != firstMagic) || (rtcStateVersion != rtcStateVersionMagic);
         ESP_LOGD(TAG, "Check if first boot: %d.", isFirst);
         return isFirst;
     }
@@ -679,6 +689,7 @@ namespace PowerFeather
         persistedChargerInitSignature.hasSignature = true;
 
         first = firstMagic;
+        rtcStateVersion = rtcStateVersionMagic;
         _initDone = true;
 
         ESP_LOGD(TAG, "Initialization done.");

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -296,7 +296,8 @@ namespace PowerFeather
             RET_IF_FALSE(getCharger().setBATFETDelay(BQ2562x::BATFETDelay::Delay20ms), Result::Failure);
             RET_IF_FALSE(getCharger().enableWVBUS(true), Result::Failure);
             RET_IF_FALSE(getCharger().setTopOff(BQ2562x::TopOffTimer::Timer17Min), Result::Failure);
-            RET_IF_FALSE(getCharger().setIbatPk(BQ2562x::IbatPkLimit::Limit3A), Result::Failure);
+            // BQ25622E/BQ25628E currently document only 6 A and 12 A IBAT_PK values.
+            RET_IF_FALSE(getCharger().setIbatPk(BQ2562x::IbatPkLimit::Limit6A), Result::Failure);
             RET_IF_FALSE(getCharger().setTH456(BQ2562x::TH456Setting::TH4_35_TH5_40_TH6_50), Result::Failure);
             RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Precool, BQ2562x::TempIset::Ichg40), Result::Failure);
             RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Prewarm, BQ2562x::TempIset::Ichg40), Result::Failure);

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -42,6 +42,10 @@
 #include <esp_log.h>
 #include <esp_timer.h>
 
+#if defined(ARDUINO)
+#include <Arduino.h>
+#endif
+
 #include "Mainboard.h"
 
 namespace PowerFeather
@@ -50,10 +54,32 @@ namespace PowerFeather
 
     static const char *TAG = "PowerFeather::Mainboard";
 
+#ifndef POWERFEATHER_ENABLE_PF_STATE_STREAM
+#define POWERFEATHER_ENABLE_PF_STATE_STREAM 0
+#endif
+
     /*extern*/ Mainboard &Board = Mainboard::get();
 
     namespace
     {
+        static constexpr const char *kPfStateFormat =
+            "snapshot retained_valid=%d rtc_cold=%d first=%d charger_sig_match=%d fg_had_sig=%d fg_force_reinit=%d fg_external_temp=%d learned_state_present=%d "
+            "current_chg_src=%u current_chg_cap=%u current_chg_term=%u current_chg_cv=%u current_chg_hash=%lu current_chg_battery_expected=%d current_chg_has_sig=%d "
+            "persisted_chg_src=%u persisted_chg_cap=%u persisted_chg_term=%u persisted_chg_cv=%u persisted_chg_hash=%lu persisted_chg_battery_expected=%d persisted_chg_has_sig=%d "
+            "last_fg_src=%u last_fg_cap=%u last_fg_term=%u last_fg_cv=%u last_fg_hash=%lu last_fg_has_sig=%d "
+            "persisted_fg_src=%u persisted_fg_cap=%u persisted_fg_term=%u persisted_fg_cv=%u persisted_fg_hash=%lu persisted_fg_has_sig=%d";
+
+        template <typename... Args>
+        static void emitPfStateSnapshot(Args... args)
+        {
+            char line[1024];
+            snprintf(line, sizeof(line), kPfStateFormat, args...);
+            ESP_LOGI("PF_STATE", "%s", line);
+#if POWERFEATHER_ENABLE_PF_STATE_STREAM && defined(ARDUINO)
+            Serial.printf("PF_STATE %s\n", line);
+#endif
+        }
+
         static uint32_t fnv1aHash(const void *data, size_t size)
         {
             const uint8_t *bytes = static_cast<const uint8_t *>(data);
@@ -299,6 +325,14 @@ namespace PowerFeather
             uint32_t scaled = (static_cast<uint32_t>(designCapRaw) * maxMah + 0x7FFFu) / 0xFFFFu;
             return static_cast<uint16_t>(std::min<uint32_t>(scaled, maxMah));
         }
+
+        struct InitDecisionState
+        {
+            bool lastInitFuelGaugeHadSignature = false;
+            bool lastInitFuelGaugeForceReinit = false;
+        };
+
+        static InitDecisionState initDecisionState;
     }
 
     #define LOG_FAIL(r)                 ESP_LOGD(TAG, "Unexpected result %d on %s:%d.", (r), __FUNCTION__, __LINE__)
@@ -406,11 +440,32 @@ namespace PowerFeather
                             signature.terminationCurrentMa != _lastFuelGaugeInitSignature.terminationCurrentMa ||
                             signature.chargeVoltageMv != _lastFuelGaugeInitSignature.chargeVoltageMv ||
                             signature.profileHash != _lastFuelGaugeInitSignature.profileHash);
+        initDecisionState.lastInitFuelGaugeHadSignature = hadFuelGaugeInitSignature;
+        initDecisionState.lastInitFuelGaugeForceReinit = forceReinit;
+        ESP_LOGI(TAG,
+                 "Fuel gauge init decision: had_sig=%d curr[src=%u cap=%u term=%u cv=%u hash=%08lx] prev[src=%u cap=%u term=%u cv=%u hash=%08lx] force_reinit=%d",
+                 hadFuelGaugeInitSignature,
+                 static_cast<unsigned>(signature.source),
+                 static_cast<unsigned>(signature.capacityMah),
+                 static_cast<unsigned>(signature.terminationCurrentMa),
+                 static_cast<unsigned>(signature.chargeVoltageMv),
+                 static_cast<unsigned long>(signature.profileHash),
+                 static_cast<unsigned>(_lastFuelGaugeInitSignature.source),
+                 static_cast<unsigned>(_lastFuelGaugeInitSignature.capacityMah),
+                 static_cast<unsigned>(_lastFuelGaugeInitSignature.terminationCurrentMa),
+                 static_cast<unsigned>(_lastFuelGaugeInitSignature.chargeVoltageMv),
+                 static_cast<unsigned long>(_lastFuelGaugeInitSignature.profileHash),
+                 forceReinit);
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
         FuelGaugeImpl &typedGauge = static_cast<FuelGaugeImpl &>(gauge);
         FuelGaugeRestoreGuard<FuelGaugeImpl> restoreGuard(typedGauge);
         if (_hasFuelGaugeInitSignature && !forceReinit)
         {
+            ESP_LOGI(TAG,
+                     "Fuel gauge retained fast path: using_external_temp=%d learned_state_present=%d profile_source=%d",
+                     _fuelGaugeUsingExternalTemp,
+                     persistedFuelGaugeLearnedState.hasState,
+                     config.source == FuelGauge::InitSource::Profile_Max17260);
             RET_IF_FALSE(FuelGaugeTempModeHelper<FuelGaugeImpl>::syncUsingExternalTemp(
                              typedGauge, _fuelGaugeUsingExternalTemp),
                          Result::Failure);
@@ -426,6 +481,11 @@ namespace PowerFeather
             // signature, should return to the documented default internal-
             // temperature mode. Preserve external-temperature mode only on the
             // retained fast path where the battery/profile inputs still match.
+            ESP_LOGI(TAG,
+                     "Fuel gauge reset path: had_sig=%d force_reinit=%d clearing_external_temp_mode learned_state_present=%d",
+                     _hasFuelGaugeInitSignature,
+                     forceReinit,
+                     persistedFuelGaugeLearnedState.hasState);
             _fuelGaugeUsingExternalTemp = false;
             RET_IF_FALSE(FuelGaugeLearnedStateHelper<FuelGaugeImpl>::syncBeforeInit(
                              typedGauge, false, persistedFuelGaugeLearnedState),
@@ -695,7 +755,21 @@ namespace PowerFeather
         _tsEnabled = false;
         _vindpm = _minSupplyMaintainVoltage;
         bool chargerSignatureMatch = false;
-        if (!_isFirst())
+        const bool firstBoot = _isFirst();
+        initDecisionState.lastInitFuelGaugeHadSignature = false;
+        initDecisionState.lastInitFuelGaugeForceReinit = false;
+        ESP_LOGI(TAG,
+                 "Init context: first=%d rtc_version=0x%08lx battery_type=%d cap=%u term=%u cv=%u use_profile=%d profile_hash=%08lx charging_supported=%d",
+                 firstBoot,
+                 static_cast<unsigned long>(rtcStateVersion),
+                 static_cast<int>(_batteryType),
+                 static_cast<unsigned>(_batteryCapacity),
+                 static_cast<unsigned>(_terminationCurrent),
+                 static_cast<unsigned>(_chargeVoltageMv),
+                 useProfile,
+                 static_cast<unsigned long>(_profileHash),
+                 chargingSupported);
+        if (!firstBoot)
         {
             chargerSignatureMatch = persistedChargerInitSignature.hasSignature &&
                                     persistedChargerInitSignature.source == currentChargerInitSignature.source &&
@@ -704,6 +778,26 @@ namespace PowerFeather
                                     persistedChargerInitSignature.chargeVoltageMv == currentChargerInitSignature.chargeVoltageMv &&
                                     persistedChargerInitSignature.profileHash == currentChargerInitSignature.profileHash &&
                                     persistedChargerInitSignature.batteryExpected == currentChargerInitSignature.batteryExpected;
+            ESP_LOGI(TAG,
+                     "Charger signature: match=%d persisted[src=%u cap=%u term=%u cv=%u hash=%08lx battery_expected=%d has_sig=%d] current[src=%u cap=%u term=%u cv=%u hash=%08lx battery_expected=%d] persisted_state[chg_en=%d ichg=%u ts=%d vindpm=%u]",
+                     chargerSignatureMatch,
+                     static_cast<unsigned>(persistedChargerInitSignature.source),
+                     static_cast<unsigned>(persistedChargerInitSignature.capacityMah),
+                     static_cast<unsigned>(persistedChargerInitSignature.terminationCurrentMa),
+                     static_cast<unsigned>(persistedChargerInitSignature.chargeVoltageMv),
+                     static_cast<unsigned long>(persistedChargerInitSignature.profileHash),
+                     persistedChargerInitSignature.batteryExpected,
+                     persistedChargerInitSignature.hasSignature,
+                     static_cast<unsigned>(currentChargerInitSignature.source),
+                     static_cast<unsigned>(currentChargerInitSignature.capacityMah),
+                     static_cast<unsigned>(currentChargerInitSignature.terminationCurrentMa),
+                     static_cast<unsigned>(currentChargerInitSignature.chargeVoltageMv),
+                     static_cast<unsigned long>(currentChargerInitSignature.profileHash),
+                     currentChargerInitSignature.batteryExpected,
+                     persistedChargerState.chargingEnabled,
+                     static_cast<unsigned>(persistedChargerState.chargingCurrentLimit),
+                     persistedChargerState.tsEnabled,
+                     static_cast<unsigned>(persistedChargerState.vindpm));
             if (chargerSignatureMatch)
             {
                 // Warm boot with unchanged battery/profile inputs: retain the
@@ -712,6 +806,21 @@ namespace PowerFeather
                 _chargingCurrentLimit = persistedChargerState.chargingCurrentLimit;
                 _tsEnabled = persistedChargerState.tsEnabled;
                 _vindpm = persistedChargerState.vindpm;
+                ESP_LOGI(TAG,
+                         "Rehydrated charger state from RTC: chg_en=%d ichg=%u ts=%d vindpm=%u",
+                         _chargingEnabled,
+                         static_cast<unsigned>(_chargingCurrentLimit),
+                         _tsEnabled,
+                         static_cast<unsigned>(_vindpm));
+            }
+            else
+            {
+                ESP_LOGI(TAG,
+                         "Warm boot with signature mismatch: keeping safe defaults chg_en=%d ichg=%u ts=%d vindpm=%u",
+                         _chargingEnabled,
+                         static_cast<unsigned>(_chargingCurrentLimit),
+                         _tsEnabled,
+                         static_cast<unsigned>(_vindpm));
             }
             _lastFuelGaugeInitSignature.source = static_cast<FuelGauge::InitSource>(persistedFuelGaugeInitSignature.source);
             _lastFuelGaugeInitSignature.capacityMah = persistedFuelGaugeInitSignature.capacityMah;
@@ -722,6 +831,7 @@ namespace PowerFeather
         }
         else
         {
+            ESP_LOGI(TAG, "Cold boot: clearing retained charger/fuel-gauge signatures and learned state");
             // Cold boot: RTC_NOINIT_ATTR leaves persistedChargerState undefined.
             // Seed it with the defaults above so that a warm boot prior to any
             // setter call rehydrates known-good values instead of RTC garbage.
@@ -740,7 +850,6 @@ namespace PowerFeather
             _lastFuelGaugeInitSignature = {};
             _hasFuelGaugeInitSignature = false;
         }
-
         if (_batteryCapacity && !chargingSupported)
         {
             // Tiny V2 packs are supported for monitoring only. Reset any
@@ -779,6 +888,15 @@ namespace PowerFeather
                 return Result::Failure;
             }
 
+            ESP_LOGI(TAG,
+                     "Applying charger init state: first=%d sig_match=%d chosen_state[chg_en=%d ichg=%u ts=%d vindpm=%u cv=%u]",
+                     firstBoot,
+                     chargerSignatureMatch,
+                     _chargingEnabled,
+                     static_cast<unsigned>(_chargingCurrentLimit),
+                     _tsEnabled,
+                     static_cast<unsigned>(_vindpm),
+                     static_cast<unsigned>(_chargeVoltageMv));
             // _reapplyChargerConfig is gated on the charger watchdog (POR indicator).
             // On wdOn == true (first init, or chip POR since last init), it applies the
             // full configuration using the software state set above — which on a warm
@@ -798,12 +916,20 @@ namespace PowerFeather
                 RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
             }
 
-            if (!_isFirst() && !chargerSignatureMatch)
+            if (firstBoot || !chargerSignatureMatch)
             {
-                // On a warm boot with changed battery/profile inputs, the
-                // charger may have retained the previous session's live state
-                // even though software intentionally reset to safe defaults.
-                // Push those defaults into the retained hardware as well.
+                ESP_LOGI(TAG,
+                         "%s: pushing software charger state into retained charger hardware chg_en=%d ichg=%u ts=%d vindpm=%u",
+                         firstBoot ? "Cold boot" : "Warm boot signature mismatch",
+                         _chargingEnabled,
+                         static_cast<unsigned>(_chargingCurrentLimit),
+                         _tsEnabled,
+                         static_cast<unsigned>(_vindpm));
+                // On a cold boot or a warm boot with changed battery/profile
+                // inputs, the charger may have retained the previous session's
+                // live state even though software intentionally selected safe
+                // defaults. Push those software-selected values into the
+                // retained hardware as well.
                 RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
                 RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
                 RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
@@ -849,6 +975,45 @@ namespace PowerFeather
         first = firstMagic;
         rtcStateVersion = rtcStateVersionMagic;
         _initDone = true;
+
+        emitPfStateSnapshot((first == firstMagic) && (rtcStateVersion == rtcStateVersionMagic),
+                 !((first == firstMagic) && (rtcStateVersion == rtcStateVersionMagic)),
+                 firstBoot,
+                 chargerSignatureMatch,
+                 initDecisionState.lastInitFuelGaugeHadSignature,
+                 initDecisionState.lastInitFuelGaugeForceReinit,
+#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
+                 _fuelGaugeUsingExternalTemp,
+#else
+                 false,
+#endif
+                 persistedFuelGaugeLearnedState.hasState,
+                 static_cast<unsigned>(currentChargerInitSignature.source),
+                 static_cast<unsigned>(currentChargerInitSignature.capacityMah),
+                 static_cast<unsigned>(currentChargerInitSignature.terminationCurrentMa),
+                 static_cast<unsigned>(currentChargerInitSignature.chargeVoltageMv),
+                 static_cast<unsigned long>(currentChargerInitSignature.profileHash),
+                 currentChargerInitSignature.batteryExpected,
+                 _initDone,
+                 static_cast<unsigned>(persistedChargerInitSignature.source),
+                 static_cast<unsigned>(persistedChargerInitSignature.capacityMah),
+                 static_cast<unsigned>(persistedChargerInitSignature.terminationCurrentMa),
+                 static_cast<unsigned>(persistedChargerInitSignature.chargeVoltageMv),
+                 static_cast<unsigned long>(persistedChargerInitSignature.profileHash),
+                 persistedChargerInitSignature.batteryExpected,
+                 persistedChargerInitSignature.hasSignature,
+                 static_cast<unsigned>(_lastFuelGaugeInitSignature.source),
+                 static_cast<unsigned>(_lastFuelGaugeInitSignature.capacityMah),
+                 static_cast<unsigned>(_lastFuelGaugeInitSignature.terminationCurrentMa),
+                 static_cast<unsigned>(_lastFuelGaugeInitSignature.chargeVoltageMv),
+                 static_cast<unsigned long>(_lastFuelGaugeInitSignature.profileHash),
+                 _hasFuelGaugeInitSignature,
+                 static_cast<unsigned>(persistedFuelGaugeInitSignature.source),
+                 static_cast<unsigned>(persistedFuelGaugeInitSignature.capacityMah),
+                 static_cast<unsigned>(persistedFuelGaugeInitSignature.terminationCurrentMa),
+                 static_cast<unsigned>(persistedFuelGaugeInitSignature.chargeVoltageMv),
+                 static_cast<unsigned long>(persistedFuelGaugeInitSignature.profileHash),
+                 persistedFuelGaugeInitSignature.hasSignature);
 
         ESP_LOGD(TAG, "Initialization done.");
 

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -84,6 +84,40 @@ namespace PowerFeather
             }
         };
 
+        template <typename Gauge>
+        struct FuelGaugeTempModeHelper
+        {
+            static bool syncUsingExternalTemp(Gauge &, bool &)
+            {
+                return true;
+            }
+        };
+
+        template <>
+        struct FuelGaugeTempModeHelper<MAX17260>
+        {
+            static bool syncUsingExternalTemp(MAX17260 &gauge, bool &usingExternalTemp)
+            {
+                if (!gauge.probe())
+                {
+                    return false;
+                }
+
+                bool initialized = false;
+                if (!gauge.getInitialized(initialized))
+                {
+                    return false;
+                }
+
+                if (!initialized)
+                {
+                    return true;
+                }
+
+                return gauge.getUsingExternalTemperature(usingExternalTemp);
+            }
+        };
+
         static uint16_t designCapToMah(uint16_t designCapRaw, uint16_t maxMah)
         {
             // MAX17260 profile DesignCap is a normalized 16-bit value.
@@ -143,6 +177,12 @@ namespace PowerFeather
         FuelGauge &gauge = getFuelGauge();
         FuelGauge::InitConfig config;
         FuelGaugeInitSignature signature;
+
+#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
+        RET_IF_FALSE(FuelGaugeTempModeHelper<FuelGaugeImpl>::syncUsingExternalTemp(
+                         static_cast<FuelGaugeImpl &>(gauge), _fuelGaugeUsingExternalTemp),
+                     Result::Failure);
+#endif
 
         if (_usesProfile)
         {

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -172,6 +172,125 @@ namespace PowerFeather
             }
         };
 
+        struct PersistedFuelGaugeLearnedState
+        {
+            uint16_t fullCapRep;
+            uint16_t fullCapNom;
+            uint16_t rComp0;
+            uint16_t tempCo;
+            uint16_t cycles;
+            bool hasState;
+        };
+
+        template <typename Gauge>
+        struct FuelGaugeLearnedStateHelper
+        {
+            static bool syncBeforeInit(Gauge &, bool, PersistedFuelGaugeLearnedState &)
+            {
+                return true;
+            }
+
+            static bool captureAfterInit(Gauge &, PersistedFuelGaugeLearnedState &)
+            {
+                return true;
+            }
+
+            static void clearPendingRestore(Gauge &) {}
+        };
+
+        template <>
+        struct FuelGaugeLearnedStateHelper<MAX17260>
+        {
+            static bool syncBeforeInit(MAX17260 &gauge,
+                                       bool allowRestore,
+                                       PersistedFuelGaugeLearnedState &persistedState)
+            {
+                if (!allowRestore)
+                {
+                    gauge.clearRestoreLearnedParameters();
+                    return true;
+                }
+
+                bool initialized = false;
+                if (!gauge.getInitialized(initialized))
+                {
+                    return false;
+                }
+
+                if (!initialized)
+                {
+                    if (persistedState.hasState)
+                    {
+                        MAX17260::LearnedParameters parameters = {};
+                        parameters.fullCapRep = persistedState.fullCapRep;
+                        parameters.fullCapNom = persistedState.fullCapNom;
+                        parameters.rComp0 = persistedState.rComp0;
+                        parameters.tempCo = persistedState.tempCo;
+                        parameters.cycles = persistedState.cycles;
+                        gauge.setRestoreLearnedParameters(parameters);
+                    }
+                    else
+                    {
+                        gauge.clearRestoreLearnedParameters();
+                    }
+                    return true;
+                }
+
+                MAX17260::LearnedParameters parameters = {};
+                if (gauge.getLearnedParameters(parameters))
+                {
+                    persistedState.fullCapRep = parameters.fullCapRep;
+                    persistedState.fullCapNom = parameters.fullCapNom;
+                    persistedState.rComp0 = parameters.rComp0;
+                    persistedState.tempCo = parameters.tempCo;
+                    persistedState.cycles = parameters.cycles;
+                    persistedState.hasState = true;
+                }
+                else
+                {
+                    persistedState.hasState = false;
+                }
+
+                gauge.clearRestoreLearnedParameters();
+                return true;
+            }
+
+            static bool captureAfterInit(MAX17260 &gauge, PersistedFuelGaugeLearnedState &persistedState)
+            {
+                MAX17260::LearnedParameters parameters = {};
+                if (!gauge.getLearnedParameters(parameters))
+                {
+                    persistedState.hasState = false;
+                    return true;
+                }
+
+                persistedState.fullCapRep = parameters.fullCapRep;
+                persistedState.fullCapNom = parameters.fullCapNom;
+                persistedState.rComp0 = parameters.rComp0;
+                persistedState.tempCo = parameters.tempCo;
+                persistedState.cycles = parameters.cycles;
+                persistedState.hasState = true;
+                return true;
+            }
+
+            static void clearPendingRestore(MAX17260 &gauge)
+            {
+                gauge.clearRestoreLearnedParameters();
+            }
+        };
+
+        template <typename Gauge>
+        struct FuelGaugeRestoreGuard
+        {
+            explicit FuelGaugeRestoreGuard(Gauge &gauge) : gauge(gauge) {}
+            ~FuelGaugeRestoreGuard()
+            {
+                FuelGaugeLearnedStateHelper<Gauge>::clearPendingRestore(gauge);
+            }
+
+            Gauge &gauge;
+        };
+
         static uint16_t designCapToMah(uint16_t designCapRaw, uint16_t maxMah)
         {
             // MAX17260 profile DesignCap is a normalized 16-bit value.
@@ -191,7 +310,7 @@ namespace PowerFeather
     static RTC_NOINIT_ATTR uint32_t first;
     static RTC_NOINIT_ATTR uint32_t rtcStateVersion;
     static const uint32_t firstMagic = 0xdeadbeef;
-    static const uint32_t rtcStateVersionMagic = 0x20260423;
+    static const uint32_t rtcStateVersionMagic = 0x20260424;
 
     // Charger state the user has committed via public setters. Placed in RTC
     // slow memory so it survives deep sleep and can be re-applied to the chip
@@ -227,6 +346,7 @@ namespace PowerFeather
         bool hasSignature;
     };
     static RTC_NOINIT_ATTR PersistedFuelGaugeInitSignature persistedFuelGaugeInitSignature;
+    static RTC_NOINIT_ATTR PersistedFuelGaugeLearnedState persistedFuelGaugeLearnedState;
 
     FuelGauge &Mainboard::getFuelGauge()
     {
@@ -245,6 +365,7 @@ namespace PowerFeather
         FuelGauge &gauge = getFuelGauge();
         FuelGauge::InitConfig config;
         FuelGaugeInitSignature signature;
+        const bool hadFuelGaugeInitSignature = _hasFuelGaugeInitSignature;
 
         if (_usesProfile)
         {
@@ -286,10 +407,17 @@ namespace PowerFeather
                             signature.chargeVoltageMv != _lastFuelGaugeInitSignature.chargeVoltageMv ||
                             signature.profileHash != _lastFuelGaugeInitSignature.profileHash);
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
+        FuelGaugeImpl &typedGauge = static_cast<FuelGaugeImpl &>(gauge);
+        FuelGaugeRestoreGuard<FuelGaugeImpl> restoreGuard(typedGauge);
         if (_hasFuelGaugeInitSignature && !forceReinit)
         {
             RET_IF_FALSE(FuelGaugeTempModeHelper<FuelGaugeImpl>::syncUsingExternalTemp(
-                             static_cast<FuelGaugeImpl &>(gauge), _fuelGaugeUsingExternalTemp),
+                             typedGauge, _fuelGaugeUsingExternalTemp),
+                         Result::Failure);
+            RET_IF_FALSE(FuelGaugeLearnedStateHelper<FuelGaugeImpl>::syncBeforeInit(
+                             typedGauge,
+                             config.source == FuelGauge::InitSource::Profile_Max17260,
+                             persistedFuelGaugeLearnedState),
                          Result::Failure);
         }
         else
@@ -299,10 +427,23 @@ namespace PowerFeather
             // temperature mode. Preserve external-temperature mode only on the
             // retained fast path where the battery/profile inputs still match.
             _fuelGaugeUsingExternalTemp = false;
+            RET_IF_FALSE(FuelGaugeLearnedStateHelper<FuelGaugeImpl>::syncBeforeInit(
+                             typedGauge, false, persistedFuelGaugeLearnedState),
+                         Result::Failure);
         }
         config.tsenseEnabled = !_fuelGaugeUsingExternalTemp;
 #endif
         RET_IF_FALSE(gauge.init(config, forceReinit), Result::Failure);
+#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
+        RET_IF_FALSE(FuelGaugeLearnedStateHelper<FuelGaugeImpl>::captureAfterInit(
+                         typedGauge, persistedFuelGaugeLearnedState),
+                     Result::Failure);
+#endif
+        if (!hadFuelGaugeInitSignature || forceReinit)
+        {
+            persistedFuelGaugeLearnedState.hasState = config.source == FuelGauge::InitSource::Profile_Max17260 &&
+                                                      persistedFuelGaugeLearnedState.hasState;
+        }
         _lastFuelGaugeInitSignature = signature;
         _hasFuelGaugeInitSignature = true;
         persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(signature.source);
@@ -595,6 +736,7 @@ namespace PowerFeather
             persistedFuelGaugeInitSignature.chargeVoltageMv = 0;
             persistedFuelGaugeInitSignature.profileHash = 0;
             persistedFuelGaugeInitSignature.hasSignature = false;
+            persistedFuelGaugeLearnedState.hasState = false;
             _lastFuelGaugeInitSignature = {};
             _hasFuelGaugeInitSignature = false;
         }

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -740,6 +740,15 @@ namespace PowerFeather
         static constexpr uint16_t _chargerADCWaitTime = 100; // 80 ms actual
         static constexpr uint16_t _batfetCtrlWaitTime = 30; // 30 ms actual
 
+        struct FuelGaugeInitSignature
+        {
+            FuelGauge::InitSource source{FuelGauge::InitSource::Generic_3V7};
+            uint16_t capacityMah{0};
+            uint16_t terminationCurrentMa{0};
+            uint16_t chargeVoltageMv{0};
+            uint32_t profileHash{0};
+        };
+
 #ifdef ARDUINO
         ArduinoMasterI2C _i2c{_i2cPort, Pin::SDA1, Pin::SCL1, _i2cFreq};
 #else
@@ -759,10 +768,13 @@ namespace PowerFeather
         uint16_t _chargeVoltageMv{4200};
         uint16_t _chargingCurrentLimit{_defaultMaxChargingCurrent};
         uint16_t _vindpm{_minSupplyMaintainVoltage};
+        uint32_t _profileHash{0};
         bool _tsEnabled{false};
         bool _chargingEnabled{false};
         BatteryType _batteryType{BatteryType::Generic_3V7};
         bool _usesProfile{false};
+        FuelGaugeInitSignature _lastFuelGaugeInitSignature{};
+        bool _hasFuelGaugeInitSignature{false};
         Mutex _mutex{100};
 
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -154,6 +154,8 @@ namespace PowerFeather
          *
          * @param[in] capacity The capacity of the connected Li-ion/LiPo battery in milliamp-hours (mAh).
          * Valid range depends on board revision: V1 supports 50-6000 mAh, V2 supports 1-16383 mAh.
+         * On V2, capacities below 50 mAh are supported for monitoring only: battery charging remains disabled
+         * and charge-current configuration is rejected.
          * Must be non-zero; use \c init() when no battery is expected. If using multiple batteries connected
          * in parallel, specify only the capacity for one cell. Ignored when \p type is
          * \c BatteryType::ICR18650_26H or \c BatteryType::UR18650ZY.
@@ -168,6 +170,8 @@ namespace PowerFeather
          * @brief Initialize the board using a MAX17260 model profile.
          *
          * The battery capacity is inferred from the profile.
+         * On V2, inferred capacities below 50 mAh are supported for monitoring only: battery charging remains
+         * disabled and charge-current configuration is rejected.
          *
          * The profile must provide a valid charger constant-voltage target in \c chargeVoltageMv.
          * Accepted range is 3500-4800 mV.
@@ -367,6 +371,7 @@ namespace PowerFeather
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
+         * On V2, charging is not available for configured battery capacities below 50 mAh.
          *
          * @param[in] enable If \c true, battery charging is enabled; if \c false, battery charging is disabled.
          *
@@ -387,6 +392,7 @@ namespace PowerFeather
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
+         * On V2, this function is not available for configured battery capacities below 50 mAh.
          *
          * @param[in] current The maximum charging current in milliamps (mA), up to 2000 mA.
          *
@@ -732,6 +738,7 @@ namespace PowerFeather
         static constexpr uint32_t _i2cTimeout = 1000;
 
         static constexpr uint16_t _defaultMaxChargingCurrent = 50; // minimum charge current at 1C
+        static constexpr uint16_t _minChargeableBatteryCapacity = _defaultMaxChargingCurrent;
         static constexpr uint16_t _minSupplyMaintainVoltage = BQ2562x::ResetVINDPMVoltage;
 
         static_assert(_minSupplyMaintainVoltage >= BQ2562x::MinVINDPMVoltage);

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -757,6 +757,10 @@ namespace PowerFeather
         uint16_t _batteryCapacity{0};
         uint16_t _terminationCurrent{0};
         uint16_t _chargeVoltageMv{4200};
+        uint16_t _chargingCurrentLimit{_defaultMaxChargingCurrent};
+        uint16_t _vindpm{_minSupplyMaintainVoltage};
+        bool _tsEnabled{false};
+        bool _chargingEnabled{false};
         BatteryType _batteryType{BatteryType::Generic_3V7};
         bool _usesProfile{false};
         Mutex _mutex{100};
@@ -773,6 +777,7 @@ namespace PowerFeather
         uint16_t _capacityFromProfile(const MAX17260::Model &profile) const;
         Result _initInternal(uint16_t capacity, BatteryType type, const MAX17260::Model *profile);
         Result _udpateChargerADC();
+        Result _reapplyChargerConfig();
 
         bool _isFuelGaugeEnabled();
         Result _initFuelGauge();

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -33,6 +33,7 @@
  */
 #pragma once
 
+#include <driver/gpio.h>
 #include <driver/rtc_io.h>
 
 #ifdef ARDUINO

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -438,7 +438,8 @@ namespace PowerFeather
         /**
          * @brief Measure battery voltage.
          *
-         * Resolution is 2 mV.
+         * Resolution is 2 mV. If the fuel gauge is enabled and available, it is used;
+         * otherwise, the charger VBAT ADC path is used as a fallback.
          *
          * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          *

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -755,6 +755,7 @@ namespace PowerFeather
         uint32_t _chargerADCTime{0};
         uint16_t _batteryCapacity{0};
         uint16_t _terminationCurrent{0};
+        uint16_t _chargeVoltageMv{4200};
         BatteryType _batteryType{BatteryType::Generic_3V7};
         bool _usesProfile{false};
         Mutex _mutex{100};

--- a/src/Utils/MasterI2C.cpp
+++ b/src/Utils/MasterI2C.cpp
@@ -44,41 +44,132 @@ namespace PowerFeather
 
     bool MasterI2C::start()
     {
-        i2c_config_t conf;
-        memset(&conf, 0, sizeof(conf));
-        conf.mode = I2C_MODE_MASTER;
-        conf.sda_io_num = _sdaPin;
-        conf.scl_io_num = _sclPin;
-        conf.sda_pullup_en = GPIO_PULLUP_DISABLE;
-        conf.scl_pullup_en = GPIO_PULLUP_DISABLE;
-        conf.master.clk_speed = _freq;
-        i2c_param_config(_port, &conf);
-        ESP_LOGD(TAG, "Start with port: %d, sda: %d, scl: %d, freq: %d.", _port, _sdaPin, _sclPin, static_cast<int>(_freq));
-        return i2c_driver_install(_port, conf.mode, 0, 0, 0) == ESP_OK;
+        if (_bus)
+        {
+            return true;
+        }
+
+        i2c_master_bus_config_t conf = {};
+        conf.i2c_port = _port;
+        conf.sda_io_num = static_cast<gpio_num_t>(_sdaPin);
+        conf.scl_io_num = static_cast<gpio_num_t>(_sclPin);
+        conf.clk_source = I2C_CLK_SRC_DEFAULT;
+        conf.glitch_ignore_cnt = 7;
+        conf.flags.enable_internal_pullup = false;
+
+        esp_err_t result = i2c_new_master_bus(&conf, &_bus);
+        ESP_LOGD(TAG, "Start with port: %d, sda: %d, scl: %d, freq: %d, result: %s.",
+                 static_cast<int>(_port), _sdaPin, _sclPin, static_cast<int>(_freq), esp_err_to_name(result));
+        return result == ESP_OK;
+    }
+
+    bool MasterI2C::_getDevice(uint8_t address, i2c_master_dev_handle_t &device)
+    {
+        if (!_bus || address >= _firstInvalid7BitAddress)
+        {
+            return false;
+        }
+
+        Device *availableDevice = nullptr;
+        for (Device &registeredDevice : _devices)
+        {
+            if (!registeredDevice.handle)
+            {
+                if (!availableDevice)
+                {
+                    availableDevice = &registeredDevice;
+                }
+                continue;
+            }
+
+            if (registeredDevice.address == address)
+            {
+                device = registeredDevice.handle;
+                return true;
+            }
+        }
+
+        if (!availableDevice)
+        {
+            ESP_LOGD(TAG, "No free device slot for address: %02x.", address);
+            return false;
+        }
+
+        i2c_device_config_t conf = {};
+        conf.dev_addr_length = I2C_ADDR_BIT_LEN_7;
+        conf.device_address = address;
+        conf.scl_speed_hz = _freq;
+
+        esp_err_t result = i2c_master_bus_add_device(_bus, &conf, &availableDevice->handle);
+        ESP_LOGD(TAG, "Add device address: %02x, result: %s.", address, esp_err_to_name(result));
+        if (result != ESP_OK)
+        {
+            availableDevice->handle = nullptr;
+            return false;
+        }
+
+        availableDevice->address = address;
+        device = availableDevice->handle;
+        return true;
     }
 
     bool MasterI2C::write(uint8_t address, uint8_t reg, const uint8_t *buf, size_t len)
     {
+        i2c_master_dev_handle_t device = nullptr;
+        if (!_getDevice(address, device))
+        {
+            return false;
+        }
+
         uint8_t buf2[len + sizeof(reg)];
         memcpy(buf2, &reg, sizeof(reg));
         memcpy(&(buf2[sizeof(reg)]), buf, len);
         ESP_LOGV(TAG, "Write address: %02x, reg: %02x, buf: %p, len: %d.", address, reg, buf, len);
         ESP_LOG_BUFFER_HEX_LEVEL(TAG, buf, len, ESP_LOG_VERBOSE);
-        return i2c_master_write_to_device(_port, address, const_cast<uint8_t*>(buf2), sizeof(buf2), pdMS_TO_TICKS(1000)) == ESP_OK;
+        return i2c_master_transmit(device, buf2, sizeof(buf2), _transferTimeoutMs) == ESP_OK;
     }
 
     bool MasterI2C::read(uint8_t address, uint8_t reg, uint8_t *buf, size_t len)
     {
+        i2c_master_dev_handle_t device = nullptr;
+        if (!_getDevice(address, device))
+        {
+            return false;
+        }
+
         ESP_LOGV(TAG, "Read address: %02x, reg: %02x, buf: %p, len: %d.", address, reg, buf, len);
-        esp_err_t res = i2c_master_write_read_device(_port, address, &reg, sizeof(reg), buf, len, pdMS_TO_TICKS(1000));
+        esp_err_t res = i2c_master_transmit_receive(device, &reg, sizeof(reg), buf, len, _transferTimeoutMs);
         ESP_LOG_BUFFER_HEX_LEVEL(TAG, buf, len, ESP_LOG_VERBOSE);
         return res == ESP_OK;
     }
 
     bool MasterI2C::end()
     {
-        ESP_LOGD(TAG, "End");
-        return i2c_driver_delete(_port) == ESP_OK;
+        if (!_bus)
+        {
+            return true;
+        }
+
+        bool success = true;
+        for (Device &registeredDevice : _devices)
+        {
+            if (registeredDevice.handle)
+            {
+                esp_err_t result = i2c_master_bus_rm_device(registeredDevice.handle);
+                if (result != ESP_OK)
+                {
+                    ESP_LOGD(TAG, "Remove device address: %02x failed: %s.",
+                             registeredDevice.address, esp_err_to_name(result));
+                    success = false;
+                }
+                registeredDevice.handle = nullptr;
+            }
+        }
+
+        esp_err_t result = i2c_del_master_bus(_bus);
+        ESP_LOGD(TAG, "End, result: %s.", esp_err_to_name(result));
+        _bus = nullptr;
+        return success && result == ESP_OK;
     }
 }
 

--- a/src/Utils/MasterI2C.h
+++ b/src/Utils/MasterI2C.h
@@ -34,10 +34,12 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 
 #ifndef ARDUINO
-#include <driver/i2c.h> // TODO: need to use updated driver
+#include <driver/i2c_master.h>
 #endif
 
 namespace PowerFeather
@@ -47,7 +49,7 @@ namespace PowerFeather
     public:
 #ifndef ARDUINO
         MasterI2C(uint8_t port, uint8_t sdaPin, uint8_t sclPin, uint32_t freq) :
-                _port(static_cast<i2c_port_t>(port)), _sdaPin(sdaPin), _sclPin(sclPin), _freq(freq) {};
+                _port(static_cast<i2c_port_num_t>(port)), _sdaPin(sdaPin), _sclPin(sclPin), _freq(freq) {};
 #else
         MasterI2C(uint8_t port, uint8_t sdaPin, uint8_t sclPin, uint32_t freq) :
                 _port(port), _sdaPin(sdaPin), _sclPin(sclPin), _freq(freq) {};
@@ -60,12 +62,30 @@ namespace PowerFeather
 
     protected:
 #ifndef ARDUINO
-        i2c_port_t _port;
+        i2c_port_num_t _port;
 #else
         uint8_t _port;
 #endif
         uint8_t _sdaPin;
         uint8_t _sclPin;
         uint32_t _freq;
+
+#ifndef ARDUINO
+    private:
+        struct Device
+        {
+            uint8_t address{0};
+            i2c_master_dev_handle_t handle{nullptr};
+        };
+
+        static constexpr uint8_t _firstInvalid7BitAddress = 0x80;
+        static constexpr size_t _maxDevices = 8;
+        static constexpr int _transferTimeoutMs = 1000;
+
+        bool _getDevice(uint8_t address, i2c_master_dev_handle_t &device);
+
+        i2c_master_bus_handle_t _bus{nullptr};
+        Device _devices[_maxDevices]{};
+#endif
     };
 }

--- a/src/Utils/Mutex.cpp
+++ b/src/Utils/Mutex.cpp
@@ -42,8 +42,11 @@ namespace PowerFeather
 
     void Mutex::init()
     {
-        _sem = xSemaphoreCreateRecursiveMutex();
-        ESP_LOGD(TAG, "Mutex %p created.", this);
+        if (_sem == nullptr)
+        {
+            _sem = xSemaphoreCreateRecursiveMutex();
+            ESP_LOGD(TAG, "Mutex %p created.", this);
+        }
     }
 
     bool Mutex::lock()

--- a/src/Utils/Mutex.cpp
+++ b/src/Utils/Mutex.cpp
@@ -60,6 +60,17 @@ namespace PowerFeather
         return false;
     }
 
+    bool Mutex::lockBlocking()
+    {
+        if (xSemaphoreTakeRecursive(_sem, portMAX_DELAY) == pdTRUE)
+        {
+            ESP_LOGD(TAG, "Mutex %p blocking take succeeded.", this);
+            return true;
+        }
+        ESP_LOGD(TAG, "Failed to take mutex %p (blocking).", this);
+        return false;
+    }
+
     void Mutex::unlock()
     {
         xSemaphoreGiveRecursive(_sem);

--- a/src/Utils/Mutex.h
+++ b/src/Utils/Mutex.h
@@ -55,7 +55,7 @@ namespace PowerFeather
             bool _locked;
         };
 
-        Mutex(uint32_t timeout) : _timeout(timeout) {}
+        Mutex(uint32_t timeout) : _sem(nullptr), _timeout(timeout) {}
 
         void init();
         bool lock();

--- a/src/Utils/Mutex.h
+++ b/src/Utils/Mutex.h
@@ -59,6 +59,7 @@ namespace PowerFeather
 
         void init();
         bool lock();
+        bool lockBlocking();
         void unlock();
 
     private:


### PR DESCRIPTION
- Fix issues identified by LLMs, especially surrounding charger and fuel gauge state across sleep modes, reset, PORs. Add support for testing these fixes.
- Update to new-style drivers. Minimum ESP-IDF version required is now 5.2