### PR TITLE
Use float in API, clean-up issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The following boards are supported:
 
 Setup for supported platforms is documented on [docs.powerfeather.dev/sdk/setup](https://docs.powerfeather.dev/sdk/setup).
 
+## V2 API Units
+
+The high-level `Mainboard` voltage APIs use `float` volts. Current APIs use `float` milliamps.
+For example, V1 code that passed `4600` mV to `setSupplyMaintainVoltage()` should pass `4.6f`
+with the V2 API, while a charging current limit of `100` mA should be passed as `100.0f`.
+
 ## Examples
 
 ### Arduino

--- a/examples/SupplyAndBatteryInfo/SupplyAndBatteryInfo.ino
+++ b/examples/SupplyAndBatteryInfo/SupplyAndBatteryInfo.ino
@@ -9,8 +9,8 @@ bool inited = false;
 
 void setup()
 {
-  pinMode(BTN, INPUT);
-  pinMode(LED, OUTPUT);
+  pinMode(Mainboard::Pin::BTN, INPUT);
+  pinMode(Mainboard::Pin::LED, OUTPUT);
 
   delay(1000);
 
@@ -23,7 +23,7 @@ void setup()
   if (initResult == Result::Ok) // check if initialization succeeded
   {
     printf("Board initialized successfully\n\n");
-    Board.setBatteryChargingMaxCurrent(100); // set max charging current to 100 mA
+    Board.setBatteryChargingMaxCurrent(100.0f); // set max charging current to 100 mA
     inited = true;
   }
 }
@@ -34,15 +34,15 @@ void loop()
   if (inited)
   {
     // Toggle green user LED
-    digitalWrite(LED, !(digitalRead(LED)));
+    digitalWrite(Mainboard::Pin::LED, !(digitalRead(Mainboard::Pin::LED)));
 
     // Only enable charging when button is pressed.
     // When charging is enabled, red CHG LED turns on.
-    Board.enableBatteryCharging(digitalRead(BTN) == LOW); // BTN is LOW when pressed
+    Board.enableBatteryCharging(digitalRead(Mainboard::Pin::BTN) == LOW); // BTN is LOW when pressed
 
     // Get information about supply and battery
-    uint16_t supplyVoltage = 0, batteryVoltage = 0;
-    int16_t supplyCurrent = 0, batteryCurrent = 0;
+    float supplyVoltage = 0.0f, batteryVoltage = 0.0f;
+    float supplyCurrent = 0.0f, batteryCurrent = 0.0f;
     uint8_t batteryCharge = 0;
 
     Board.getSupplyVoltage(supplyVoltage);
@@ -51,8 +51,8 @@ void loop()
     Board.getBatteryVoltage(batteryVoltage);
     Board.getBatteryCurrent(batteryCurrent);
 
-    printf("[Supply]  Voltage: %d mV    Current: %d mA\n", supplyVoltage, supplyCurrent);
-    printf("[Battery] Voltage: %d mV    Current: %d mA    ", batteryVoltage, batteryCurrent);
+    printf("[Supply]  Voltage: %.3f V    Current: %.1f mA\n", supplyVoltage, supplyCurrent);
+    printf("[Battery] Voltage: %.3f V    Current: %.1f mA    ", batteryVoltage, batteryCurrent);
 
     // Check the result for getting battery charge.
     Result res = Board.getBatteryCharge(batteryCharge);

--- a/examples/supply_and_battery_info/main/supply_and_battery_info.cpp
+++ b/examples/supply_and_battery_info/main/supply_and_battery_info.cpp
@@ -30,7 +30,7 @@ extern "C" void app_main()
     if (initResult == Result::Ok) // check if initialization succeeded
     {
         printf("Board initialized successfully\n\n");
-        Board.setBatteryChargingMaxCurrent(100); // set max charging current to 100 mA
+        Board.setBatteryChargingMaxCurrent(100.0f); // set max charging current to 100 mA
         inited = true;
     }
 
@@ -46,8 +46,8 @@ extern "C" void app_main()
             Board.enableBatteryCharging(gpio_get_level(Mainboard::Pin::BTN) == 0); // BTN is LOW when pressed
 
             // Get information about supply and battery
-            uint16_t supplyVoltage = 0, batteryVoltage = 0;
-            int16_t supplyCurrent = 0, batteryCurrent = 0;
+            float supplyVoltage = 0.0f, batteryVoltage = 0.0f;
+            float supplyCurrent = 0.0f, batteryCurrent = 0.0f;
             uint8_t batteryCharge = 0;
 
             Board.getSupplyVoltage(supplyVoltage);
@@ -56,8 +56,8 @@ extern "C" void app_main()
             Board.getBatteryVoltage(batteryVoltage);
             Board.getBatteryCurrent(batteryCurrent);
 
-            printf("[Supply]  Voltage: %d mV    Current: %d mA\n", supplyVoltage, supplyCurrent);
-            printf("[Battery] Voltage: %d mV    Current: %d mA    ", batteryVoltage, batteryCurrent);
+            printf("[Supply]  Voltage: %.3f V    Current: %.1f mA\n", supplyVoltage, supplyCurrent);
+            printf("[Battery] Voltage: %.3f V    Current: %.1f mA    ", batteryVoltage, batteryCurrent);
 
             // Check the result for getting battery charge.
             Result res = Board.getBatteryCharge(batteryCharge);

--- a/src/Mainboard/BQ2562x.cpp
+++ b/src/Mainboard/BQ2562x.cpp
@@ -52,6 +52,11 @@ namespace PowerFeather
         {
             return static_cast<uint16_t>(std::lround(value / step));
         }
+
+        static uint16_t toRawFloor(float value, float step)
+        {
+            return static_cast<uint16_t>(std::floor(value / step));
+        }
     }
 
     template <typename T>
@@ -366,7 +371,7 @@ namespace PowerFeather
     {
         if (current >= BQ2562x::MinChargingCurrent && current <= BQ2562x::MaxChargingCurrent)
         {
-            uint16_t value = toRawNearest(current, 40.0f);
+            uint16_t value = toRawFloor(current, 40.0f);
             return _writeReg(Charge_Current_Limit_ICHG, value);
         }
         return false;

--- a/src/Mainboard/BQ2562x.cpp
+++ b/src/Mainboard/BQ2562x.cpp
@@ -32,7 +32,7 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <math.h>
+#include <cmath>
 #include <limits.h>
 
 #include <esp_log.h>
@@ -43,6 +43,16 @@
 namespace PowerFeather
 {
     static const char *TAG = "PowerFeather::Mainboard::BQ2562x";
+
+    namespace
+    {
+        static constexpr float MillivoltsPerVolt = 1000.0f;
+
+        static uint16_t toRawNearest(float value, float step)
+        {
+            return static_cast<uint16_t>(std::lround(value / step));
+        }
+    }
 
     template <typename T>
     bool BQ2562x::_readReg(Register reg, T &value)
@@ -102,18 +112,18 @@ namespace PowerFeather
         return _readReg(Charger_Control_0_WATCHDOG, enabled);
     }
 
-    bool BQ2562x::getVBUS(uint16_t &voltage)
+    bool BQ2562x::getVBUS(float &voltage)
     {
         uint16_t value = 0;
         if (_readReg(VBUS_ADC, value))
         {
-            voltage = round(Util::fromRaw(value, 3.97f));
+            voltage = Util::fromRaw(value, 3.97f) / MillivoltsPerVolt;
             return true;
         }
         return false;
     }
 
-    bool BQ2562x::getIBUS(int16_t &current)
+    bool BQ2562x::getIBUS(float &current)
     {
         uint16_t value = 0;
 
@@ -127,18 +137,18 @@ namespace PowerFeather
         return false;
     }
 
-    bool BQ2562x::getVBAT(uint16_t &voltage)
+    bool BQ2562x::getVBAT(float &voltage)
     {
         uint16_t value = 0;
         if (_readReg(VBAT_ADC, value))
         {
-            voltage = round(Util::fromRaw(value, 1.99f));
+            voltage = Util::fromRaw(value, 1.99f) / MillivoltsPerVolt;
             return true;
         }
         return false;
     }
 
-    bool BQ2562x::getIBAT(int16_t &current)
+    bool BQ2562x::getIBAT(float &current)
     {
         // 0x2000 is an invalid value carried over from bq25622e.
         static constexpr uint16_t invalid = 0x2000;
@@ -246,34 +256,34 @@ namespace PowerFeather
         return false;
     }
 
-    bool BQ2562x::getVINDPM(uint16_t& voltage)
+    bool BQ2562x::getVINDPM(float& voltage)
     {
         uint16_t value = 0;
         if (_readReg(Input_Current_Limit_VINDPM, value))
         {
-            voltage = round(Util::fromRaw(value, 40.0f));
+            voltage = Util::fromRaw(value, 40.0f) / MillivoltsPerVolt;
             return true;
         }
         return false;
     }
 
-    bool BQ2562x::getChargeCurrentLimit(uint16_t& current)
+    bool BQ2562x::getChargeCurrentLimit(float& current)
     {
         uint16_t value = 0;
         if (_readReg(Charge_Current_Limit_ICHG, value))
         {
-            current = round(Util::fromRaw(value, 40.0f));
+            current = Util::fromRaw(value, 40.0f);
             return true;
         }
         return false;
     }
 
-    bool BQ2562x::getChargeVoltageLimit(uint16_t& voltage)
+    bool BQ2562x::getChargeVoltageLimit(float& voltage)
     {
         uint16_t value = 0;
         if (_readReg(Charge_Voltage_Limit_VREG, value))
         {
-            voltage = round(Util::fromRaw(value, 10.0f));
+            voltage = Util::fromRaw(value, 10.0f) / MillivoltsPerVolt;
             return true;
         }
         return false;
@@ -352,24 +362,24 @@ namespace PowerFeather
         return _writeReg(reg, !enable);
     }
 
-    bool BQ2562x::setChargeCurrentLimit(uint16_t current)
+    bool BQ2562x::setChargeCurrentLimit(float current)
     {
         if (current >= BQ2562x::MinChargingCurrent && current <= BQ2562x::MaxChargingCurrent)
         {
-            uint16_t value = round(Util::toRaw(current, 40.0f));
+            uint16_t value = toRawNearest(current, 40.0f);
             return _writeReg(Charge_Current_Limit_ICHG, value);
         }
         return false;
     }
 
-    bool BQ2562x::setChargeVoltageLimit(uint16_t voltage)
+    bool BQ2562x::setChargeVoltageLimit(float voltage)
     {
-        static constexpr uint16_t minVoltageMv = 3500;
-        static constexpr uint16_t maxVoltageMv = 4800;
+        static constexpr float minVoltage = 3.5f;
+        static constexpr float maxVoltage = 4.8f;
 
-        if (voltage >= minVoltageMv && voltage <= maxVoltageMv)
+        if (voltage >= minVoltage && voltage <= maxVoltage)
         {
-            uint16_t value = round(Util::toRaw(static_cast<float>(voltage), 10.0f));
+            uint16_t value = toRawNearest(voltage * MillivoltsPerVolt, 10.0f);
             return _writeReg(Charge_Voltage_Limit_VREG, value);
         }
         return false;
@@ -387,31 +397,31 @@ namespace PowerFeather
         return _writeReg(Charger_Control_2_BATFET_DLY, value);
     }
 
-    bool BQ2562x::setVINDPM(uint16_t voltage)
+    bool BQ2562x::setVINDPM(float voltage)
     {
         if (voltage >= BQ2562x::MinVINDPMVoltage && voltage <= BQ2562x::MaxVINDPMVoltage)
         {
-            uint16_t value = Util::toRaw(voltage, 40.0f);
+            uint16_t value = toRawNearest(voltage * MillivoltsPerVolt, 40.0f);
             return _writeReg(Input_Current_Limit_VINDPM, value);
         }
         return false;
     }
 
-    bool BQ2562x::setIINDPM(uint16_t current)
+    bool BQ2562x::setIINDPM(float current)
     {
         if (current >= BQ2562x::MinIINDPMCurrent && current <= BQ2562x::MaxIINDPMCurrent)
         {
-            uint16_t value = Util::toRaw(current, 20.0f);
+            uint16_t value = toRawNearest(current, 20.0f);
             return _writeReg(Input_Current_Limit_IINDPM, value);
         }
         return false;
     }
 
-    bool BQ2562x::setITERM(uint16_t current)
+    bool BQ2562x::setITERM(float current)
     {
         if (current >= BQ2562x::MinITERMCurrent && current <= BQ2562x::MaxITERMCurrent)
         {
-            uint16_t value = Util::toRaw(current, 5.0f);
+            uint16_t value = toRawNearest(current, 5.0f);
             return _writeReg(Termination_Control_0_ITERM, value);
         }
         return false;

--- a/src/Mainboard/BQ2562x.h
+++ b/src/Mainboard/BQ2562x.h
@@ -121,8 +121,12 @@ namespace PowerFeather
 
         enum class BATFETDelay : uint8_t
         {
-            Delay20ms = 0x00,
+            Delay25ms = 0x00,
             Delay10s = 0x01,
+
+            // Backward-compatible alias for the old SDK spelling. The BQ2562x
+            // datasheets define this BATFET_DLY encoding as 25 ms.
+            Delay20ms = Delay25ms,
         };
 
         enum class Adc : uint8_t

--- a/src/Mainboard/BQ2562x.h
+++ b/src/Mainboard/BQ2562x.h
@@ -45,9 +45,9 @@ namespace PowerFeather
         static constexpr uint16_t MinChargingCurrent = 40;
         static constexpr uint16_t MaxChargingCurrent = 2000;
 
-        static constexpr uint16_t MinVINDPMVoltage = 4600;
-        static constexpr uint16_t MaxVINDPMVoltage = 16800;
-        static constexpr uint16_t ResetVINDPMVoltage = 4600;
+        static constexpr float MinVINDPMVoltage = 4.6f;
+        static constexpr float MaxVINDPMVoltage = 16.8f;
+        static constexpr float ResetVINDPMVoltage = 4.6f;
 
         static constexpr uint16_t MinIINDPMCurrent = 100;
         static constexpr uint16_t MaxIINDPMCurrent = 3200;
@@ -189,11 +189,12 @@ namespace PowerFeather
 
         BQ2562x(MasterI2C &i2c) : _i2c(i2c) {}
 
+        // Voltage APIs use volts (V). Current APIs use milliamps (mA).
         bool getWD(bool &enabled);
-        bool getVBUS(uint16_t &voltage);
-        bool getIBUS(int16_t &current);
-        bool getVBAT(uint16_t &voltage);
-        bool getIBAT(int16_t &current);
+        bool getVBUS(float &voltage);
+        bool getIBUS(float &current);
+        bool getVBAT(float &voltage);
+        bool getIBAT(float &current);
         bool getADCDone(bool &done);
         bool getTSEnabled(bool &enabled);
         bool getTSBias(float &voltage);
@@ -201,9 +202,9 @@ namespace PowerFeather
         bool getChargeStat(ChargeStat &stat);
         bool getChargingEnabled(bool& enabled);
         bool getSTATEnabled(bool& enabled);
-        bool getVINDPM(uint16_t& voltage);
-        bool getChargeCurrentLimit(uint16_t& current);
-        bool getChargeVoltageLimit(uint16_t& voltage);
+        bool getVINDPM(float& voltage);
+        bool getChargeCurrentLimit(float& current);
+        bool getChargeVoltageLimit(float& voltage);
         bool getPartInformation(uint8_t &info);
 
         bool setWD(WatchdogTimer timer);
@@ -215,13 +216,13 @@ namespace PowerFeather
         bool enableWVBUS(bool enable);
         bool enableADC(Adc adc, bool enable);
         bool enableSTAT(bool enable);
-        bool setChargeCurrentLimit(uint16_t current);
-        bool setChargeVoltageLimit(uint16_t voltage);
+        bool setChargeCurrentLimit(float current);
+        bool setChargeVoltageLimit(float voltage);
         bool setBATFETControl(BATFETControl control);
         bool setBATFETDelay(BATFETDelay delay);
-        bool setVINDPM(uint16_t voltage);
-        bool setIINDPM(uint16_t current);
-        bool setITERM(uint16_t current);
+        bool setVINDPM(float voltage);
+        bool setIINDPM(float current);
+        bool setITERM(float current);
         bool setTopOff(TopOffTimer timer);
         bool setIbatPk(IbatPkLimit limit);
         bool setTH456(TH456Setting setting);

--- a/src/Mainboard/BQ2562x.h
+++ b/src/Mainboard/BQ2562x.h
@@ -122,11 +122,14 @@ namespace PowerFeather
         enum class BATFETDelay : uint8_t
         {
             Delay25ms = 0x00,
-            Delay10s = 0x01,
+            Delay12_5s = 0x01,
 
             // Backward-compatible alias for the old SDK spelling. The BQ2562x
             // datasheets define this BATFET_DLY encoding as 25 ms.
             Delay20ms = Delay25ms,
+            // Backward-compatible alias for the old SDK spelling. The BQ2562x
+            // datasheets define this BATFET_DLY encoding as 12.5 s.
+            Delay10s = Delay12_5s,
         };
 
         enum class Adc : uint8_t

--- a/src/Mainboard/FuelGauge.h
+++ b/src/Mainboard/FuelGauge.h
@@ -62,7 +62,7 @@ namespace PowerFeather
             {
                 uint16_t capacityMah;
                 uint16_t terminationCurrentMa;
-                uint16_t chargeVoltageMv;
+                float chargeVoltage;
             };
 
             struct ProfileConfig
@@ -75,7 +75,7 @@ namespace PowerFeather
                 CapacityConfig capacity;
                 ProfileConfig profile;
 
-                constexpr Payload() : capacity{0, 0, 0} {}
+                constexpr Payload() : capacity{0, 0, 0.0f} {}
             };
 
             InitSource source{InitSource::Generic_3V7};
@@ -87,8 +87,9 @@ namespace PowerFeather
 
         bool init(const InitConfig &config, bool forceReinit = false);
 
+        // Voltage APIs use volts (V). Temperature APIs use degrees Celsius.
         virtual bool getEnabled(bool &enabled) = 0;
-        virtual bool getCellVoltage(uint16_t &voltage) = 0;
+        virtual bool getCellVoltage(float &voltage) = 0;
         virtual bool getRSOC(uint8_t &percent) = 0;
         virtual bool getTimeToEmpty(uint16_t &minutes) = 0;
         virtual bool getTimeToFull(uint16_t &minutes) = 0;
@@ -99,8 +100,8 @@ namespace PowerFeather
         virtual bool setEnabled(bool enable) = 0;
         virtual bool setCellTemperature(float temperature) = 0;
         virtual bool enableTSENSE(bool enableTsense1, bool enableTsense2) = 0;
-        virtual bool setLowVoltageAlarm(uint16_t voltage) = 0;
-        virtual bool setHighVoltageAlarm(uint16_t voltage) = 0;
+        virtual bool setLowVoltageAlarm(float voltage) = 0;
+        virtual bool setHighVoltageAlarm(float voltage) = 0;
         virtual bool setLowRSOCAlarm(uint8_t percent) = 0;
         virtual bool setTerminationFactor(float factor) = 0;
         virtual bool setInitialized() = 0;
@@ -110,7 +111,7 @@ namespace PowerFeather
 
         virtual bool probe() = 0;
         virtual const char *getName() const = 0;
-        virtual void getVoltageAlarmRange(uint16_t &minMv, uint16_t &maxMv) const = 0;
+        virtual void getVoltageAlarmRange(float &minV, float &maxV) const = 0;
         virtual void getTemperatureRange(float &minC, float &maxC) const = 0;
         virtual void getTerminationFactorRange(float &minFactor, float &maxFactor) const = 0;
         virtual void getBatteryCapacityRange(uint16_t &minMah, uint16_t &maxMah) const = 0;

--- a/src/Mainboard/LC709204F.cpp
+++ b/src/Mainboard/LC709204F.cpp
@@ -32,7 +32,7 @@
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <math.h>
+#include <cmath>
 
 #include <esp_log.h>
 
@@ -42,6 +42,11 @@
 namespace PowerFeather
 {
     static const char *TAG = "PowerFeather::Mainboard::LC709204F";
+
+    namespace
+    {
+        static constexpr float MillivoltsPerVolt = 1000.0f;
+    }
 
     bool LC709204F::readRegister(uint8_t address, uint16_t &data)
     {
@@ -128,11 +133,12 @@ namespace PowerFeather
         return crc;
     }
 
-    bool LC709204F::_setVoltageAlarm(Register reg, uint16_t voltage)
+    bool LC709204F::_setVoltageAlarm(Register reg, float voltage)
     {
         if (voltage == 0 || (voltage >= LC709204F::MinVoltageAlarm && voltage <= LC709204F::MaxVoltageAlarm))
         {
-            return writeRegister(static_cast<uint8_t>(reg), voltage);
+            uint16_t rawMv = static_cast<uint16_t>(std::lround(voltage * MillivoltsPerVolt));
+            return writeRegister(static_cast<uint8_t>(reg), rawMv);
         }
         return false;
     }
@@ -153,9 +159,15 @@ namespace PowerFeather
         return res;
     }
 
-    bool LC709204F::getCellVoltage(uint16_t &voltage)
+    bool LC709204F::getCellVoltage(float &voltage)
     {
-        return readRegister(static_cast<uint8_t>(Register::Cell_Voltage), voltage);
+        uint16_t rawMv = 0;
+        if (readRegister(static_cast<uint8_t>(Register::Cell_Voltage), rawMv))
+        {
+            voltage = static_cast<float>(rawMv) / MillivoltsPerVolt;
+            return true;
+        }
+        return false;
     }
 
     bool LC709204F::getRSOC(uint8_t &percent)
@@ -294,12 +306,12 @@ namespace PowerFeather
         return writeRegister(static_cast<uint8_t>(Register::Status_Bit), status);
     }
 
-    bool LC709204F::setLowVoltageAlarm(uint16_t voltage)
+    bool LC709204F::setLowVoltageAlarm(float voltage)
     {
         return _setVoltageAlarm(Register::Alarm_Low_Cell_Voltage, voltage);
     }
 
-    bool LC709204F::setHighVoltageAlarm(uint16_t voltage)
+    bool LC709204F::setHighVoltageAlarm(float voltage)
     {
         return _setVoltageAlarm(Register::Alarm_High_Cell_Voltage, voltage);
     }

--- a/src/Mainboard/LC709204F.h
+++ b/src/Mainboard/LC709204F.h
@@ -59,10 +59,10 @@ namespace PowerFeather
 
         bool probe() override;
         const char *getName() const override { return "LC709204F"; }
-        void getVoltageAlarmRange(uint16_t &minMv, uint16_t &maxMv) const override
+        void getVoltageAlarmRange(float &minV, float &maxV) const override
         {
-            minMv = MinVoltageAlarm;
-            maxMv = MaxVoltageAlarm;
+            minV = MinVoltageAlarm;
+            maxV = MaxVoltageAlarm;
         }
         void getTemperatureRange(float &minC, float &maxC) const override
         {
@@ -81,7 +81,7 @@ namespace PowerFeather
         }
 
         bool getEnabled(bool &enabled) override;
-        bool getCellVoltage(uint16_t &voltage) override;
+        bool getCellVoltage(float &voltage) override;
         bool getRSOC(uint8_t &percent) override;
         bool getTimeToEmpty(uint16_t &minutes) override;
         bool getTimeToFull(uint16_t &minutes) override;
@@ -94,8 +94,8 @@ namespace PowerFeather
         bool setChangeOfParameter(ChangeOfParameter changeOfParam);
         bool setCellTemperature(float temperature) override;
         bool enableTSENSE(bool enableTsense1, bool enableTsense2) override;
-        bool setLowVoltageAlarm(uint16_t voltage) override;
-        bool setHighVoltageAlarm(uint16_t voltage) override;
+        bool setLowVoltageAlarm(float voltage) override;
+        bool setHighVoltageAlarm(float voltage) override;
         bool setLowRSOCAlarm(uint8_t percent) override;
         bool setTerminationFactor(float factor);
         bool setInitialized();
@@ -106,8 +106,8 @@ namespace PowerFeather
     private:
         static constexpr uint16_t MaxBatteryCapacity = 6000;
         static constexpr uint16_t MinBatteryCapacity = 50;
-        static constexpr uint16_t MinVoltageAlarm = 2500;
-        static constexpr uint16_t MaxVoltageAlarm = 5000;
+        static constexpr float MinVoltageAlarm = 2.5f;
+        static constexpr float MaxVoltageAlarm = 5.0f;
         static constexpr float MaxTerminationFactor = 0.3f;
         static constexpr float MinTerminationFactor = 0.02f;
 
@@ -203,7 +203,7 @@ namespace PowerFeather
 
         uint8_t _computeCRC8(uint8_t *data, int len);
 
-        bool _setVoltageAlarm(Register reg, uint16_t voltage);
+        bool _setVoltageAlarm(Register reg, float voltage);
         bool _clearAlarm(const Field &alarmField);
         bool initImpl(const InitConfig &config) override;
     };

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -176,6 +176,15 @@ namespace PowerFeather
             return false;
         }
 
+        LearnedParameters restoreParameters = {};
+        const LearnedParameters *restoreParametersPtr = nullptr;
+        if (_hasRestoreLearnedParameters)
+        {
+            restoreParameters = _restoreLearnedParameters;
+            restoreParametersPtr = &restoreParameters;
+            _hasRestoreLearnedParameters = false;
+        }
+
         if (config.source == FuelGauge::InitSource::Profile_Max17260)
         {
             const Model *model = static_cast<const Model *>(config.data.profile.model);
@@ -186,15 +195,6 @@ namespace PowerFeather
                     return false;
                 }
                 model = &_profile;
-            }
-
-            LearnedParameters restoreParameters = {};
-            const LearnedParameters *restoreParametersPtr = nullptr;
-            if (_hasRestoreLearnedParameters)
-            {
-                restoreParameters = _restoreLearnedParameters;
-                restoreParametersPtr = &restoreParameters;
-                _hasRestoreLearnedParameters = false;
             }
 
             return _loadModel(*model, restoreParametersPtr);
@@ -215,10 +215,10 @@ namespace PowerFeather
                 return false;
         }
 
-        return _initEZConfig(config, modelId);
+        return _initEZConfig(config, modelId, restoreParametersPtr);
     }
 
-    bool MAX17260::_initEZConfig(const InitConfig &config, uint8_t modelId)
+    bool MAX17260::_initEZConfig(const InitConfig &config, uint8_t modelId, const LearnedParameters *savedParameters)
     {
         if (!_waitForDNRClear())
         {
@@ -255,6 +255,63 @@ namespace PowerFeather
         if (!_waitForModelRefreshClear())
         {
             return false;
+        }
+
+        if (savedParameters)
+        {
+            if (!_writeAndVerify(Register::FullCapRep, savedParameters->fullCapRep)) return false;
+
+            const uint16_t dQAcc = static_cast<uint16_t>(savedParameters->fullCapNom / 2u);
+            constexpr uint16_t dPAcc = 0x0C80;
+            bool verified = false;
+            for (int attempt = 0; attempt < 3; ++attempt)
+            {
+                if (!writeRegister(Register::dQAcc, dQAcc)) return false;
+                if (!writeRegister(Register::dPAcc, dPAcc)) return false;
+                vTaskDelay(pdMS_TO_TICKS(10));
+                if (!writeRegister(Register::FullCapNom, savedParameters->fullCapNom)) return false;
+
+                uint16_t checkFullCapNom = 0;
+                uint16_t checkDQAcc = 0;
+                uint16_t checkDPAcc = 0;
+                if (!readRegister(Register::FullCapNom, checkFullCapNom) ||
+                    !readRegister(Register::dQAcc, checkDQAcc) ||
+                    !readRegister(Register::dPAcc, checkDPAcc))
+                {
+                    return false;
+                }
+
+                if (checkFullCapNom == savedParameters->fullCapNom &&
+                    checkDQAcc == dQAcc &&
+                    checkDPAcc == dPAcc)
+                {
+                    verified = true;
+                    break;
+                }
+            }
+
+            if (!verified)
+            {
+                return false;
+            }
+
+            uint16_t vfsoc = 0;
+            if (!readRegister(Register::VFSOC, vfsoc))
+            {
+                return false;
+            }
+
+            uint32_t updateCapacity =
+                (static_cast<uint32_t>(vfsoc) * savedParameters->fullCapNom) / 25600u;
+            uint16_t updateCapacity16 = static_cast<uint16_t>(std::min<uint32_t>(updateCapacity, 0xFFFFu));
+            if (!writeRegister(Register::MixCap, updateCapacity16)) return false;
+            if (!writeRegister(Register::AvCap, updateCapacity16)) return false;
+
+            vTaskDelay(pdMS_TO_TICKS(200));
+
+            if (!_writeAndVerify(Register::RComp0, savedParameters->rComp0)) return false;
+            if (!_writeAndVerify(Register::TempCo, savedParameters->tempCo)) return false;
+            if (!_writeAndVerify(Register::Cycles, savedParameters->cycles)) return false;
         }
 
         if (!writeRegister(Register::HibCfg, hibCfg))
@@ -598,6 +655,19 @@ namespace PowerFeather
         if (readRegister(Register::VCell, raw))
         {
             voltage = (static_cast<float>(raw) * 5.0f) / (64.0f * MillivoltsPerVolt);
+            return true;
+        }
+        return false;
+    }
+
+    bool MAX17260::getCurrent(float &current)
+    {
+        uint16_t raw = 0;
+        if (readRegister(Register::Current, raw))
+        {
+            int16_t signedRaw = static_cast<int16_t>(raw);
+            current = (static_cast<float>(signedRaw) * 25.0f) /
+                      (static_cast<float>(SenseResistorMilliohms) * 16.0f);
             return true;
         }
         return false;

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -238,7 +238,8 @@ namespace PowerFeather
         if (!writeRegister(Register::DesignCap, _capacityMahToDesignCapRaw(config.data.capacity.capacityMah))) return false;
         // This will be overwritten by _finalizeInit() with potentially better accuracy
         if (!writeRegister(Register::IChgTerm, _currentMaToRaw(config.data.capacity.terminationCurrentMa))) return false;
-        if (!writeRegister(Register::VEmpty, VEmpty_Default)) return false;
+        const uint16_t vEmpty = (modelId == ModelID_LFP) ? VEmpty_LFP : VEmpty_Default;
+        if (!writeRegister(Register::VEmpty, vEmpty)) return false;
 
         uint16_t modelCfg = ModelCfgBit_Refresh;
         modelCfg |= static_cast<uint16_t>((modelId & 0x7u) << 5);

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -703,6 +703,19 @@ namespace PowerFeather
         return false;
     }
 
+    bool MAX17260::getDesignCapacity(uint16_t &mah)
+    {
+        uint16_t raw = 0;
+        if (!readRegister(Register::DesignCap, raw))
+        {
+            return false;
+        }
+        // Inverse of _capacityMahToDesignCapRaw: mAh = raw * 5 / RSENSE_mΩ.
+        uint32_t scaled = static_cast<uint32_t>(raw) * 5u + (SenseResistorMilliohms / 2u);
+        mah = static_cast<uint16_t>(std::min<uint32_t>(scaled / SenseResistorMilliohms, 0xFFFFu));
+        return true;
+    }
+
     void MAX17260::setRestoreLearnedParameters(const LearnedParameters &parameters)
     {
         _restoreLearnedParameters = parameters;

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -141,6 +141,14 @@ namespace PowerFeather
         return static_cast<uint16_t>(std::min<uint32_t>(raw, 0xFFFFu));
     }
 
+    uint16_t MAX17260::ichgTermRawToMa(uint16_t raw)
+    {
+        // Inverse of _currentMaToRaw(): mA = raw * 25 / (RSENSE_mOhm * 16).
+        static constexpr uint32_t denom = static_cast<uint32_t>(SenseResistorMilliohms) * 16u;
+        uint32_t scaled = static_cast<uint32_t>(raw) * 25u + (denom / 2u);
+        return static_cast<uint16_t>(std::min<uint32_t>(scaled / denom, 0xFFFFu));
+    }
+
     bool MAX17260::probe()
     {
         uint16_t value = 0;

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -242,7 +242,7 @@ namespace PowerFeather
         if (!writeRegister(Register::VEmpty, vEmpty)) return false;
 
         uint16_t modelCfg = ModelCfgBit_Refresh;
-        modelCfg |= static_cast<uint16_t>((modelId & 0x7u) << 5);
+        modelCfg |= static_cast<uint16_t>((modelId & 0x7u) << ModelCfgShift_ModelID);
         if (config.data.capacity.chargeVoltage > ModelCfgHighVoltageThreshold)
         {
             modelCfg |= ModelCfgBit_VChg;
@@ -354,7 +354,7 @@ namespace PowerFeather
         }
 
         cfg &= static_cast<uint16_t>(~ModelCfgMask_ModelID);
-        cfg |= static_cast<uint16_t>((modelId & 0x7u) << 5);
+        cfg |= static_cast<uint16_t>((modelId & 0x7u) << ModelCfgShift_ModelID);
         cfg |= ModelCfgBit_Refresh;
 
         if (!writeRegister(Register::ModelCfg, cfg))

--- a/src/Mainboard/MAX17260.cpp
+++ b/src/Mainboard/MAX17260.cpp
@@ -45,6 +45,11 @@ namespace PowerFeather
 {
     static const char *TAG = "PowerFeather::Mainboard::MAX17260";
 
+    namespace
+    {
+        static constexpr float MillivoltsPerVolt = 1000.0f;
+    }
+
     bool MAX17260::readRegister(uint8_t address, uint16_t &value)
     {
         if (_i2c.read(_i2cAddress, address, reinterpret_cast<uint8_t *>(&value), registerSizeBytes()))
@@ -237,7 +242,7 @@ namespace PowerFeather
 
         uint16_t modelCfg = ModelCfgBit_Refresh;
         modelCfg |= static_cast<uint16_t>((modelId & 0x7u) << 5);
-        if (config.data.capacity.chargeVoltageMv > ModelCfgHighVoltageThresholdMv)
+        if (config.data.capacity.chargeVoltage > ModelCfgHighVoltageThreshold)
         {
             modelCfg |= ModelCfgBit_VChg;
         }
@@ -587,13 +592,12 @@ namespace PowerFeather
         return false;
     }
 
-    bool MAX17260::getCellVoltage(uint16_t &voltage)
+    bool MAX17260::getCellVoltage(float &voltage)
     {
         uint16_t raw = 0;
         if (readRegister(Register::VCell, raw))
         {
-            uint32_t mv = static_cast<uint32_t>(raw) * 5u;
-            voltage = static_cast<uint16_t>((mv + 32u) >> 6); // divide by 64 with rounding
+            voltage = (static_cast<float>(raw) * 5.0f) / (64.0f * MillivoltsPerVolt);
             return true;
         }
         return false;
@@ -810,7 +814,7 @@ namespace PowerFeather
         return writeRegister(Register::Config, newConfig);
     }
 
-    bool MAX17260::setLowVoltageAlarm(uint16_t voltage)
+    bool MAX17260::setLowVoltageAlarm(float voltage)
     {
         if (voltage != 0 && (voltage < MinVoltageAlarm || voltage > MaxVoltageAlarm))
         {
@@ -827,7 +831,7 @@ namespace PowerFeather
         uint8_t raw = 0;
         if (voltage != 0)
         {
-            uint32_t value = (static_cast<uint32_t>(voltage) + 10u) / 20u;
+            uint32_t value = static_cast<uint32_t>(std::lround((voltage * MillivoltsPerVolt) / 20.0f));
             raw = static_cast<uint8_t>(std::min<uint32_t>(value, 0xFFu));
         }
 
@@ -845,7 +849,7 @@ namespace PowerFeather
         return true;
     }
 
-    bool MAX17260::setHighVoltageAlarm(uint16_t voltage)
+    bool MAX17260::setHighVoltageAlarm(float voltage)
     {
         if (voltage != 0 && (voltage < MinVoltageAlarm || voltage > MaxVoltageAlarm))
         {
@@ -862,7 +866,7 @@ namespace PowerFeather
         uint8_t raw = 0xFF; // Writing 0xFF (5100 mV) effectively disables the alarm.
         if (voltage != 0)
         {
-            uint32_t value = (static_cast<uint32_t>(voltage) + 10u) / 20u;
+            uint32_t value = static_cast<uint32_t>(std::lround((voltage * MillivoltsPerVolt) / 20.0f));
             raw = static_cast<uint8_t>(std::min<uint32_t>(value, 0xFFu));
         }
 

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -54,6 +54,9 @@ namespace PowerFeather
 
         struct Model
         {
+            // Mainboard.cpp hashes these fields member-by-member to detect
+            // custom profile changes. If this layout changes, update
+            // hashFuelGaugeProfile() at the same time.
             std::array<uint16_t, 32> modelTable{};
             uint16_t rComp0{0};
             uint16_t tempCo{0};

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -113,6 +113,7 @@ namespace PowerFeather
 
         bool getEnabled(bool &enabled) override;
         bool getCellVoltage(float &voltage) override;
+        bool getCurrent(float &current);
         bool getRSOC(uint8_t &percent) override;
         bool getTimeToEmpty(uint16_t &minutes) override;
         bool getTimeToFull(uint16_t &minutes) override;
@@ -259,7 +260,7 @@ namespace PowerFeather
         }
         bool initImpl(const InitConfig &config) override;
         bool _verifyDeviceIdentity();
-        bool _initEZConfig(const InitConfig &config, uint8_t modelId);
+        bool _initEZConfig(const InitConfig &config, uint8_t modelId, const LearnedParameters *savedParameters);
         bool _initHardware();
         bool _waitForDNRClear();
         bool _waitForModelRefreshClear();

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -72,9 +72,9 @@ namespace PowerFeather
             uint16_t tOff{0};
             uint16_t curve{0};
             std::array<uint16_t, 4> qrTable{{0, 0, 0, 0}};
-            // Charger CV target used by Mainboard::init(const Model&), in mV.
-            // Required by profile init: valid range is 3500-4800 mV.
-            uint16_t chargeVoltageMv{0};
+            // Charger CV target used by Mainboard::init(const Model&), in V.
+            // Required by profile init: valid range is 3.5-4.8 V.
+            float chargeVoltage{0.0f};
         };
 
         static constexpr uint8_t ModelID_LiCoO2 = 0;
@@ -86,10 +86,10 @@ namespace PowerFeather
 
         bool probe() override;
         const char *getName() const override { return "MAX17260"; }
-        void getVoltageAlarmRange(uint16_t &minMv, uint16_t &maxMv) const override
+        void getVoltageAlarmRange(float &minV, float &maxV) const override
         {
-            minMv = MinVoltageAlarm;
-            maxMv = MaxVoltageAlarm;
+            minV = MinVoltageAlarm;
+            maxV = MaxVoltageAlarm;
         }
         void getTemperatureRange(float &minC, float &maxC) const override
         {
@@ -112,7 +112,7 @@ namespace PowerFeather
         void setProfile(const Model &model);
 
         bool getEnabled(bool &enabled) override;
-        bool getCellVoltage(uint16_t &voltage) override;
+        bool getCellVoltage(float &voltage) override;
         bool getRSOC(uint8_t &percent) override;
         bool getTimeToEmpty(uint16_t &minutes) override;
         bool getTimeToFull(uint16_t &minutes) override;
@@ -128,8 +128,8 @@ namespace PowerFeather
         bool setEnabled(bool enable) override;
         bool setCellTemperature(float temperature) override;
         bool enableTSENSE(bool enableTsense1, bool enableTsense2) override;
-        bool setLowVoltageAlarm(uint16_t voltage) override;
-        bool setHighVoltageAlarm(uint16_t voltage) override;
+        bool setLowVoltageAlarm(float voltage) override;
+        bool setHighVoltageAlarm(float voltage) override;
         bool setLowRSOCAlarm(uint8_t percent) override;
         bool setTerminationFactor(float factor) override;
         bool setInitialized() override;
@@ -144,10 +144,10 @@ namespace PowerFeather
         static_assert(MaxBatteryCapacityMah <= UINT16_MAX);
         static constexpr uint16_t MinBatteryCapacity = 1;
         static constexpr uint16_t MaxBatteryCapacity = static_cast<uint16_t>(MaxBatteryCapacityMah);
-        static constexpr uint16_t MinVoltageAlarm = 20;
+        static constexpr float MinVoltageAlarm = 0.02f;
         // VAlrtTh is encoded in 20mV steps with an 8-bit field (0x00..0xFF).
-        // Effective max threshold is 255 * 20mV = 5100mV.
-        static constexpr uint16_t MaxVoltageAlarm = 5100;
+        // Effective max threshold is 255 * 20mV = 5.1V.
+        static constexpr float MaxVoltageAlarm = 5.1f;
         static constexpr float MinTemperature = -128.0f;
         static constexpr float MaxTemperature = 127.996f;
         static constexpr float MinTermination = 0.01f;
@@ -220,7 +220,7 @@ namespace PowerFeather
         static constexpr uint16_t ModelCfgBit_Refresh = 1u << 15;
         static constexpr uint16_t ModelCfgBit_VChg = 1u << 10;
         static constexpr uint16_t ModelCfgMask_ModelID = 0x7u << 5;
-        static constexpr uint16_t ModelCfgHighVoltageThresholdMv = 4275;
+        static constexpr float ModelCfgHighVoltageThreshold = 4.275f;
         static constexpr uint16_t ConfigBit_TSel = 1u << 15;
         static constexpr uint16_t ConfigBit_TEn = 1u << 9;
         static constexpr uint16_t ConfigBit_TEx = 1u << 8;

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -217,6 +217,7 @@ namespace PowerFeather
         static constexpr uint16_t HibernateExit_Command2 = 0x0000;
         static constexpr uint16_t ShdnTimer_ShutdownWithin22s = 0x001E;
         static constexpr uint16_t VEmpty_Default = 0xA561;
+        static constexpr uint16_t VEmpty_LFP = 0x7D4B; // VE = 2.50 V, VR = 3.00 V.
 
         static constexpr uint16_t HibCfgBit_EnHib = 1u << 15;
         static constexpr uint16_t ModelCfgBit_Refresh = 1u << 15;

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -122,6 +122,7 @@ namespace PowerFeather
         bool getInitialized(bool& state) override;
         bool getLearnedParameters(LearnedParameters &parameters);
         bool getUsingExternalTemperature(bool &external);
+        bool getDesignCapacity(uint16_t &mah);
         void setRestoreLearnedParameters(const LearnedParameters &parameters);
         void clearRestoreLearnedParameters();
         bool setEnabled(bool enable) override;

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -72,8 +72,9 @@ namespace PowerFeather
             uint16_t tOff{0};
             uint16_t curve{0};
             std::array<uint16_t, 4> qrTable{{0, 0, 0, 0}};
-            // Charger CV target used by Mainboard::init(const Model&), in V.
-            // Required by profile init: valid range is 3.5-4.8 V.
+            // Charger VREG/CV target used by Mainboard::init(const Model&), in V.
+            // Required by profile init: valid range is 3.5-4.8 V. The caller
+            // must choose a value that is safe for the profiled cell chemistry.
             float chargeVoltage{0.0f};
         };
 

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -222,7 +222,8 @@ namespace PowerFeather
         static constexpr uint16_t HibCfgBit_EnHib = 1u << 15;
         static constexpr uint16_t ModelCfgBit_Refresh = 1u << 15;
         static constexpr uint16_t ModelCfgBit_VChg = 1u << 10;
-        static constexpr uint16_t ModelCfgMask_ModelID = 0x7u << 5;
+        static constexpr uint8_t ModelCfgShift_ModelID = 4;
+        static constexpr uint16_t ModelCfgMask_ModelID = 0x7u << ModelCfgShift_ModelID;
         static constexpr float ModelCfgHighVoltageThreshold = 4.275f;
         static constexpr uint16_t ConfigBit_TSel = 1u << 15;
         static constexpr uint16_t ConfigBit_TEn = 1u << 9;

--- a/src/Mainboard/MAX17260.h
+++ b/src/Mainboard/MAX17260.h
@@ -111,6 +111,7 @@ namespace PowerFeather
         bool setModelID(uint8_t modelId);
         bool loadModel(const Model &model);
         void setProfile(const Model &model);
+        static uint16_t ichgTermRawToMa(uint16_t raw);
 
         bool getEnabled(bool &enabled) override;
         bool getCellVoltage(float &voltage) override;

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -1061,15 +1061,9 @@ namespace PowerFeather
             // On wdOn == true (first init, or chip POR since last init), it applies the
             // full configuration using the software state set above — which on a warm
             // boot is the user's previous-session values rehydrated from RTC, not the
-            // hardcoded defaults. On wdOn == false (chip retained state), it's a no-op
-            // and the redundant setChargeVoltageLimit below is the belt-and-braces write.
+            // hardcoded defaults. On wdOn == false (chip retained state), it's a no-op.
             bool chargerConfigAppliedByWd = false;
             RET_IF_ERR(_reapplyChargerConfig(&chargerConfigAppliedByWd));
-
-            // Enforce charge voltage target on every init path, including the wdOn==false
-            // path (chip retained state across sleep but we still want to rewrite VREG
-            // in case the BatteryType chemistry selection changed since last session).
-            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltage), Result::Failure);
 
             if (_batteryCapacity && !chargingSupported)
             {
@@ -1095,6 +1089,13 @@ namespace PowerFeather
                 {
                     RET_IF_ERR(_applyChargerConfig());
                 }
+            }
+            else if (!chargerConfigAppliedByWd)
+            {
+                // Same signature and retained charger state: rewrite only VREG so
+                // the charge-voltage target is still enforced without duplicating
+                // the full policy write on cold boot or signature mismatch.
+                RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltage), Result::Failure);
             }
 
             // If battery capacity is not 0, initialize the fuel gauge. This can fail if during

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -710,8 +710,13 @@ namespace PowerFeather
         return Result::Ok;
     }
 
-    Result Mainboard::_reapplyChargerConfig()
+    Result Mainboard::_reapplyChargerConfig(bool *applied)
     {
+        if (applied)
+        {
+            *applied = false;
+        }
+
         bool wdOn = true;
         RET_IF_FALSE(getCharger().getWD(wdOn), Result::Failure);
 
@@ -719,6 +724,10 @@ namespace PowerFeather
         {
             ESP_LOGW(TAG, "Charger watchdog enabled, re-applying configuration.");
             RET_IF_ERR(_applyChargerConfig());
+            if (applied)
+            {
+                *applied = true;
+            }
         }
 
         return Result::Ok;
@@ -979,7 +988,8 @@ namespace PowerFeather
             // boot is the user's previous-session values rehydrated from RTC, not the
             // hardcoded defaults. On wdOn == false (chip retained state), it's a no-op
             // and the redundant setChargeVoltageLimit below is the belt-and-braces write.
-            RET_IF_ERR(_reapplyChargerConfig());
+            bool chargerConfigAppliedByWd = false;
+            RET_IF_ERR(_reapplyChargerConfig(&chargerConfigAppliedByWd));
 
             // Enforce charge voltage target on every init path, including the wdOn==false
             // path (chip retained state across sleep but we still want to rewrite VREG
@@ -1006,7 +1016,10 @@ namespace PowerFeather
                 // live state even though software intentionally selected safe
                 // defaults. Push the full software-selected policy into the
                 // retained hardware as well.
-                RET_IF_ERR(_applyChargerConfig());
+                if (!chargerConfigAppliedByWd)
+                {
+                    RET_IF_ERR(_applyChargerConfig());
+                }
             }
 
             // If battery capacity is not 0, initialize the fuel gauge. This can fail if during
@@ -1334,6 +1347,7 @@ namespace PowerFeather
         RET_IF_FALSE(getCharger().getChargingEnabled(chargingEnabled), Result::Failure);
         if (!chargingEnabled && current == 0.0f)
         {
+            // BQ25628E Table 8-35 specifies that IBAT_ADC resets to zero when EN_CHG=0.
             ESP_LOGD(TAG, "V1 charger battery-current ADC is unavailable while charging is disabled.");
             return Result::NotReady;
         }

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -463,6 +463,21 @@ namespace PowerFeather
         return Result::InvalidState;
 #endif
     }
+
+    Result Mainboard::testClearFuelGaugeInitSignature()
+    {
+        TRY_LOCK(_mutex);
+        _lastFuelGaugeInitSignature = {};
+        _hasFuelGaugeInitSignature = false;
+        persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(FuelGauge::InitSource::Generic_3V7);
+        persistedFuelGaugeInitSignature.capacityMah = 0;
+        persistedFuelGaugeInitSignature.terminationCurrentMa = 0;
+        persistedFuelGaugeInitSignature.chargeVoltage = 0.0f;
+        persistedFuelGaugeInitSignature.profileHash = 0;
+        persistedFuelGaugeInitSignature.hasSignature = false;
+        persistedFuelGaugeLearnedState.hasState = false;
+        return Result::Ok;
+    }
 #endif
 
     bool Mainboard::_isFuelGaugeEnabled()
@@ -512,12 +527,12 @@ namespace PowerFeather
             signature.source = config.source;
         }
 
-        bool forceReinit = _hasFuelGaugeInitSignature &&
-                           (signature.source != _lastFuelGaugeInitSignature.source ||
-                            signature.capacityMah != _lastFuelGaugeInitSignature.capacityMah ||
-                            signature.terminationCurrentMa != _lastFuelGaugeInitSignature.terminationCurrentMa ||
-                            signature.chargeVoltage != _lastFuelGaugeInitSignature.chargeVoltage ||
-                            signature.profileHash != _lastFuelGaugeInitSignature.profileHash);
+        bool signatureMismatch = signature.source != _lastFuelGaugeInitSignature.source ||
+                                 signature.capacityMah != _lastFuelGaugeInitSignature.capacityMah ||
+                                 signature.terminationCurrentMa != _lastFuelGaugeInitSignature.terminationCurrentMa ||
+                                 signature.chargeVoltage != _lastFuelGaugeInitSignature.chargeVoltage ||
+                                 signature.profileHash != _lastFuelGaugeInitSignature.profileHash;
+        bool forceReinit = !_hasFuelGaugeInitSignature || signatureMismatch;
         initDecisionState.lastInitFuelGaugeHadSignature = hadFuelGaugeInitSignature;
         initDecisionState.lastInitFuelGaugeForceReinit = forceReinit;
         ESP_LOGI(TAG,

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -37,6 +37,7 @@
 #include <cstdint>
 #include <cstring>
 #include <math.h>
+#include <type_traits>
 
 #include <soc/reset_reasons.h>
 #include <esp_log.h>
@@ -80,16 +81,66 @@ namespace PowerFeather
 #endif
         }
 
-        static uint32_t fnv1aHash(const void *data, size_t size)
+        static uint32_t fnv1aAppendByte(uint32_t hash, uint8_t byte)
         {
-            const uint8_t *bytes = static_cast<const uint8_t *>(data);
-            uint32_t hash = 2166136261u;
-            for (size_t i = 0; i < size; ++i)
-            {
-                hash ^= bytes[i];
-                hash *= 16777619u;
-            }
+            hash ^= byte;
+            hash *= 16777619u;
             return hash;
+        }
+
+        static uint32_t fnv1aAppendU16(uint32_t hash, uint16_t value)
+        {
+            hash = fnv1aAppendByte(hash, static_cast<uint8_t>(value & 0xFFu));
+            return fnv1aAppendByte(hash, static_cast<uint8_t>(value >> 8));
+        }
+
+        static uint32_t fnv1aAppendU32(uint32_t hash, uint32_t value)
+        {
+            hash = fnv1aAppendByte(hash, static_cast<uint8_t>(value & 0xFFu));
+            hash = fnv1aAppendByte(hash, static_cast<uint8_t>((value >> 8) & 0xFFu));
+            hash = fnv1aAppendByte(hash, static_cast<uint8_t>((value >> 16) & 0xFFu));
+            return fnv1aAppendByte(hash, static_cast<uint8_t>(value >> 24));
+        }
+
+        static uint32_t fnv1aAppendFloat(uint32_t hash, float value)
+        {
+            static_assert(sizeof(float) == sizeof(uint32_t), "Unsupported float size.");
+            uint32_t bits = 0;
+            std::memcpy(&bits, &value, sizeof(bits));
+            return fnv1aAppendU32(hash, bits);
+        }
+
+        static uint32_t hashFuelGaugeProfile(const MAX17260::Model &profile)
+        {
+            static_assert(std::is_trivially_copyable<MAX17260::Model>::value,
+                          "MAX17260::Model must remain trivially copyable.");
+
+            uint32_t hash = 2166136261u;
+            for (uint16_t value : profile.modelTable)
+            {
+                hash = fnv1aAppendU16(hash, value);
+            }
+            hash = fnv1aAppendU16(hash, profile.rComp0);
+            hash = fnv1aAppendU16(hash, profile.tempCo);
+            hash = fnv1aAppendU16(hash, profile.rCompSeg);
+            hash = fnv1aAppendU16(hash, profile.designCap);
+            hash = fnv1aAppendU16(hash, profile.ichgTerm);
+            hash = fnv1aAppendU16(hash, profile.vEmpty);
+            hash = fnv1aAppendU16(hash, profile.modelCfg);
+            hash = fnv1aAppendU16(hash, profile.learnCfg);
+            hash = fnv1aAppendU16(hash, profile.relaxCfg);
+            hash = fnv1aAppendU16(hash, profile.config);
+            hash = fnv1aAppendU16(hash, profile.config2);
+            hash = fnv1aAppendU16(hash, profile.miscCfg);
+            hash = fnv1aAppendU16(hash, profile.fullSocThr);
+            hash = fnv1aAppendU16(hash, profile.tGain);
+            hash = fnv1aAppendU16(hash, profile.tOff);
+            hash = fnv1aAppendU16(hash, profile.curve);
+            for (uint16_t value : profile.qrTable)
+            {
+                hash = fnv1aAppendU16(hash, value);
+            }
+            return fnv1aAppendFloat(hash, profile.chargeVoltage);
         }
 
         struct ChargerInitSignature
@@ -829,7 +880,7 @@ namespace PowerFeather
         _batteryCapacity = capacity;
         _batteryType = type;
         _usesProfile = useProfile;
-        _profileHash = useProfile ? fnv1aHash(profile, sizeof(*profile)) : 0;
+        _profileHash = useProfile ? hashFuelGaugeProfile(*profile) : 0;
 
         // Set termination current to C / 10 for built-in profiles, or to the
         // characterized fuel-gauge value for custom MAX17260 profiles.

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -114,6 +114,8 @@ namespace PowerFeather
         {
             static_assert(std::is_trivially_copyable<MAX17260::Model>::value,
                           "MAX17260::Model must remain trivially copyable.");
+            static_assert(sizeof(MAX17260::Model) == 108,
+                          "MAX17260::Model changed; update hashFuelGaugeProfile().");
 
             uint32_t hash = 2166136261u;
             for (uint16_t value : profile.modelTable)

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -405,6 +405,66 @@ namespace PowerFeather
         return _fuelGauge;
     }
 
+#if POWERFEATHER_ENABLE_PF_STATE_STREAM
+    Result Mainboard::testRestoreFuelGaugeLearnedStateAfterPor()
+    {
+#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
+        TRY_LOCK(_mutex);
+        RET_IF_FALSE(_initDone, Result::InvalidState);
+        RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
+        RET_IF_FALSE(persistedFuelGaugeLearnedState.hasState, Result::NotReady);
+
+        FuelGauge::InitConfig config;
+        if (_usesProfile)
+        {
+            config.source = FuelGauge::InitSource::Profile_Max17260;
+            config.data.profile.model = nullptr;
+        }
+        else
+        {
+            config.data.capacity.capacityMah = _batteryCapacity;
+            config.data.capacity.terminationCurrentMa = _terminationCurrent;
+            config.data.capacity.chargeVoltage = _chargeVoltage;
+            switch (_batteryType)
+            {
+                case BatteryType::Generic_3V7:
+                    config.source = FuelGauge::InitSource::Generic_3V7;
+                    break;
+                case BatteryType::ICR18650_26H:
+                    config.source = FuelGauge::InitSource::ICR18650_26H;
+                    break;
+                case BatteryType::UR18650ZY:
+                    config.source = FuelGauge::InitSource::UR18650ZY;
+                    break;
+                case BatteryType::Generic_LFP:
+                    config.source = FuelGauge::InitSource::Generic_LFP;
+                    break;
+            }
+        }
+        config.tsenseEnabled = !_fuelGaugeUsingExternalTemp;
+
+        FuelGaugeImpl &typedGauge = static_cast<FuelGaugeImpl &>(getFuelGauge());
+        FuelGaugeRestoreGuard<FuelGaugeImpl> restoreGuard(typedGauge);
+
+        MAX17260::LearnedParameters parameters = {};
+        parameters.fullCapRep = persistedFuelGaugeLearnedState.fullCapRep;
+        parameters.fullCapNom = persistedFuelGaugeLearnedState.fullCapNom;
+        parameters.rComp0 = persistedFuelGaugeLearnedState.rComp0;
+        parameters.tempCo = persistedFuelGaugeLearnedState.tempCo;
+        parameters.cycles = persistedFuelGaugeLearnedState.cycles;
+        typedGauge.setRestoreLearnedParameters(parameters);
+
+        RET_IF_FALSE(typedGauge.init(config, true), Result::Failure);
+        RET_IF_FALSE(FuelGaugeLearnedStateHelper<FuelGaugeImpl>::captureAfterInit(
+                         typedGauge, persistedFuelGaugeLearnedState),
+                     Result::Failure);
+        return Result::Ok;
+#else
+        return Result::InvalidState;
+#endif
+    }
+#endif
+
     bool Mainboard::_isFuelGaugeEnabled()
     {
         bool enabled = false;
@@ -489,7 +549,7 @@ namespace PowerFeather
                          Result::Failure);
             RET_IF_FALSE(FuelGaugeLearnedStateHelper<FuelGaugeImpl>::syncBeforeInit(
                              typedGauge,
-                             config.source == FuelGauge::InitSource::Profile_Max17260,
+                             true,
                              persistedFuelGaugeLearnedState),
                          Result::Failure);
         }
@@ -517,11 +577,6 @@ namespace PowerFeather
                          typedGauge, persistedFuelGaugeLearnedState),
                      Result::Failure);
 #endif
-        if (!hadFuelGaugeInitSignature || forceReinit)
-        {
-            persistedFuelGaugeLearnedState.hasState = config.source == FuelGauge::InitSource::Profile_Max17260 &&
-                                                      persistedFuelGaugeLearnedState.hasState;
-        }
         _lastFuelGaugeInitSignature = signature;
         _hasFuelGaugeInitSignature = true;
         persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(signature.source);
@@ -629,7 +684,7 @@ namespace PowerFeather
         {
             ESP_LOGW(TAG, "Charger watchdog enabled, re-applying configuration.");
             RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
-            RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxChargingCurrent), Result::Failure);
+            RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxIINDPMCurrent), Result::Failure);
             RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
             RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
             RET_IF_FALSE(getCharger().setBATFETDelay(BQ2562x::BATFETDelay::Delay20ms), Result::Failure);
@@ -651,7 +706,6 @@ namespace PowerFeather
             }
             if (_batteryCapacity)
             {
-                RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxIINDPMCurrent), Result::Failure);
                 RET_IF_FALSE(getCharger().setITERM(_terminationCurrent), Result::Failure);
             }
             RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltage), Result::Failure);
@@ -1273,9 +1327,16 @@ namespace PowerFeather
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
+#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
+        RET_IF_FALSE(_isFuelGaugeEnabled(), Result::InvalidState);
+        RET_IF_ERR(_initFuelGauge());
+        RET_IF_FALSE(static_cast<MAX17260 &>(getFuelGauge()).getCurrent(current), Result::Failure);
+        ESP_LOGD(TAG, "Measured battery current from fuel gauge: %f mA.", current);
+#else
         RET_IF_ERR(_udpateChargerADC());
         RET_IF_FALSE(getCharger().getIBAT(current), Result::Failure);
         ESP_LOGD(TAG, "Measured battery current from charger: %f mA.", current);
+#endif
         return Result::Ok;
     }
 

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -64,10 +64,10 @@ namespace PowerFeather
     {
         static constexpr const char *kPfStateFormat =
             "snapshot retained_valid=%d rtc_cold=%d first=%d charger_sig_match=%d fg_had_sig=%d fg_force_reinit=%d fg_external_temp=%d learned_state_present=%d "
-            "current_chg_src=%u current_chg_cap=%u current_chg_term=%u current_chg_cv=%u current_chg_hash=%lu current_chg_battery_expected=%d current_chg_has_sig=%d "
-            "persisted_chg_src=%u persisted_chg_cap=%u persisted_chg_term=%u persisted_chg_cv=%u persisted_chg_hash=%lu persisted_chg_battery_expected=%d persisted_chg_has_sig=%d "
-            "last_fg_src=%u last_fg_cap=%u last_fg_term=%u last_fg_cv=%u last_fg_hash=%lu last_fg_has_sig=%d "
-            "persisted_fg_src=%u persisted_fg_cap=%u persisted_fg_term=%u persisted_fg_cv=%u persisted_fg_hash=%lu persisted_fg_has_sig=%d";
+            "current_chg_src=%u current_chg_cap=%u current_chg_term=%u current_chg_cv=%.3f current_chg_hash=%lu current_chg_battery_expected=%d current_chg_has_sig=%d "
+            "persisted_chg_src=%u persisted_chg_cap=%u persisted_chg_term=%u persisted_chg_cv=%.3f persisted_chg_hash=%lu persisted_chg_battery_expected=%d persisted_chg_has_sig=%d "
+            "last_fg_src=%u last_fg_cap=%u last_fg_term=%u last_fg_cv=%.3f last_fg_hash=%lu last_fg_has_sig=%d "
+            "persisted_fg_src=%u persisted_fg_cap=%u persisted_fg_term=%u persisted_fg_cv=%.3f persisted_fg_hash=%lu persisted_fg_has_sig=%d";
 
         template <typename... Args>
         static void emitPfStateSnapshot(Args... args)
@@ -97,7 +97,7 @@ namespace PowerFeather
             uint8_t source;
             uint16_t capacityMah;
             uint16_t terminationCurrentMa;
-            uint16_t chargeVoltageMv;
+            float chargeVoltage;
             uint32_t profileHash;
             bool batteryExpected;
         };
@@ -106,7 +106,7 @@ namespace PowerFeather
                                                              bool useProfile,
                                                              uint16_t capacityMah,
                                                              uint16_t terminationCurrentMa,
-                                                             uint16_t chargeVoltageMv,
+                                                             float chargeVoltage,
                                                              uint32_t profileHash)
         {
             ChargerInitSignature signature = {};
@@ -140,7 +140,7 @@ namespace PowerFeather
             if (signature.batteryExpected)
             {
                 signature.terminationCurrentMa = terminationCurrentMa;
-                signature.chargeVoltageMv = chargeVoltageMv;
+                signature.chargeVoltage = chargeVoltage;
             }
 
             return signature;
@@ -369,8 +369,8 @@ namespace PowerFeather
     // in _reapplyChargerConfig. Valid iff first == firstMagic (warm boot).
     struct PersistedChargerState
     {
-        uint16_t chargingCurrentLimit;
-        uint16_t vindpm;
+        float chargingCurrentLimit;
+        float vindpm;
         bool chargingEnabled;
         bool tsEnabled;
     };
@@ -381,7 +381,7 @@ namespace PowerFeather
         uint8_t source;
         uint16_t capacityMah;
         uint16_t terminationCurrentMa;
-        uint16_t chargeVoltageMv;
+        float chargeVoltage;
         uint32_t profileHash;
         bool batteryExpected;
         bool hasSignature;
@@ -393,7 +393,7 @@ namespace PowerFeather
         uint8_t source;
         uint16_t capacityMah;
         uint16_t terminationCurrentMa;
-        uint16_t chargeVoltageMv;
+        float chargeVoltage;
         uint32_t profileHash;
         bool hasSignature;
     };
@@ -430,10 +430,10 @@ namespace PowerFeather
         {
             config.data.capacity.capacityMah = _batteryCapacity;
             config.data.capacity.terminationCurrentMa = _terminationCurrent;
-            config.data.capacity.chargeVoltageMv = _chargeVoltageMv;
+            config.data.capacity.chargeVoltage = _chargeVoltage;
             signature.capacityMah = _batteryCapacity;
             signature.terminationCurrentMa = _terminationCurrent;
-            signature.chargeVoltageMv = _chargeVoltageMv;
+            signature.chargeVoltage = _chargeVoltage;
             switch (_batteryType)
             {
                 case BatteryType::Generic_3V7:
@@ -456,22 +456,22 @@ namespace PowerFeather
                            (signature.source != _lastFuelGaugeInitSignature.source ||
                             signature.capacityMah != _lastFuelGaugeInitSignature.capacityMah ||
                             signature.terminationCurrentMa != _lastFuelGaugeInitSignature.terminationCurrentMa ||
-                            signature.chargeVoltageMv != _lastFuelGaugeInitSignature.chargeVoltageMv ||
+                            signature.chargeVoltage != _lastFuelGaugeInitSignature.chargeVoltage ||
                             signature.profileHash != _lastFuelGaugeInitSignature.profileHash);
         initDecisionState.lastInitFuelGaugeHadSignature = hadFuelGaugeInitSignature;
         initDecisionState.lastInitFuelGaugeForceReinit = forceReinit;
         ESP_LOGI(TAG,
-                 "Fuel gauge init decision: had_sig=%d curr[src=%u cap=%u term=%u cv=%u hash=%08lx] prev[src=%u cap=%u term=%u cv=%u hash=%08lx] force_reinit=%d",
+                 "Fuel gauge init decision: had_sig=%d curr[src=%u cap=%u term=%u cv=%.3f hash=%08lx] prev[src=%u cap=%u term=%u cv=%.3f hash=%08lx] force_reinit=%d",
                  hadFuelGaugeInitSignature,
                  static_cast<unsigned>(signature.source),
                  static_cast<unsigned>(signature.capacityMah),
                  static_cast<unsigned>(signature.terminationCurrentMa),
-                 static_cast<unsigned>(signature.chargeVoltageMv),
+                 signature.chargeVoltage,
                  static_cast<unsigned long>(signature.profileHash),
                  static_cast<unsigned>(_lastFuelGaugeInitSignature.source),
                  static_cast<unsigned>(_lastFuelGaugeInitSignature.capacityMah),
                  static_cast<unsigned>(_lastFuelGaugeInitSignature.terminationCurrentMa),
-                 static_cast<unsigned>(_lastFuelGaugeInitSignature.chargeVoltageMv),
+                 _lastFuelGaugeInitSignature.chargeVoltage,
                  static_cast<unsigned long>(_lastFuelGaugeInitSignature.profileHash),
                  forceReinit);
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
@@ -527,7 +527,7 @@ namespace PowerFeather
         persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(signature.source);
         persistedFuelGaugeInitSignature.capacityMah = signature.capacityMah;
         persistedFuelGaugeInitSignature.terminationCurrentMa = signature.terminationCurrentMa;
-        persistedFuelGaugeInitSignature.chargeVoltageMv = signature.chargeVoltageMv;
+        persistedFuelGaugeInitSignature.chargeVoltage = signature.chargeVoltage;
         persistedFuelGaugeInitSignature.profileHash = signature.profileHash;
         persistedFuelGaugeInitSignature.hasSignature = true;
         ESP_LOGD(TAG, "Fuel gauge init complete (%s).", gauge.getName());
@@ -654,7 +654,7 @@ namespace PowerFeather
                 RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxIINDPMCurrent), Result::Failure);
                 RET_IF_FALSE(getCharger().setITERM(_terminationCurrent), Result::Failure);
             }
-            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
+            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltage), Result::Failure);
             RET_IF_FALSE(getCharger().setVINDPM(_vindpm), Result::Failure);
             RET_IF_FALSE(getCharger().setWD(BQ2562x::WatchdogTimer::Disabled), Result::Failure);
             RET_IF_FALSE(getCharger().enableCharging(_chargingEnabled), Result::Failure);
@@ -679,10 +679,10 @@ namespace PowerFeather
         uint16_t capacity = _capacityFromProfile(profile);
         RET_IF_FALSE(capacity, Result::InvalidArg);
         // Profile init must explicitly provide the charger CV target.
-        static constexpr uint16_t minProfileChargeVoltageMv = 3500;
-        static constexpr uint16_t maxProfileChargeVoltageMv = 4800;
-        RET_IF_FALSE(profile.chargeVoltageMv >= minProfileChargeVoltageMv &&
-                     profile.chargeVoltageMv <= maxProfileChargeVoltageMv, Result::InvalidArg);
+        static constexpr float minProfileChargeVoltage = 3.5f;
+        static constexpr float maxProfileChargeVoltage = 4.8f;
+        RET_IF_FALSE(profile.chargeVoltage >= minProfileChargeVoltage &&
+                     profile.chargeVoltage <= maxProfileChargeVoltage, Result::InvalidArg);
         return _initInternal(capacity, BatteryType::Generic_3V7, &profile);
     }
 
@@ -753,22 +753,22 @@ namespace PowerFeather
         _terminationCurrent = std::min(std::max(_terminationCurrent, minCurrent), maxCurrent);
         ESP_LOGI(TAG, "Termination current set to %d mA.", _terminationCurrent);
 
-        uint16_t chargeVoltageMv = 4200;
-        if (useProfile && profile->chargeVoltageMv)
+        float chargeVoltage = 4.2f;
+        if (useProfile && profile->chargeVoltage)
         {
-            chargeVoltageMv = profile->chargeVoltageMv;
+            chargeVoltage = profile->chargeVoltage;
         }
         if (_batteryType == BatteryType::Generic_LFP)
         {
-            chargeVoltageMv = 3600;
+            chargeVoltage = 3.6f;
         }
-        _chargeVoltageMv = chargeVoltageMv;
+        _chargeVoltage = chargeVoltage;
 
         ChargerInitSignature currentChargerInitSignature = makeChargerInitSignature(_batteryType,
                                                                                    _usesProfile,
                                                                                    _batteryCapacity,
                                                                                    _terminationCurrent,
-                                                                                   _chargeVoltageMv,
+                                                                                   _chargeVoltage,
                                                                                    _profileHash);
         const bool chargingSupported = (_batteryCapacity == 0) || (_batteryCapacity >= _minChargeableBatteryCapacity);
 
@@ -781,13 +781,13 @@ namespace PowerFeather
         initDecisionState.lastInitFuelGaugeHadSignature = false;
         initDecisionState.lastInitFuelGaugeForceReinit = false;
         ESP_LOGI(TAG,
-                 "Init context: first=%d rtc_version=0x%08lx battery_type=%d cap=%u term=%u cv=%u use_profile=%d profile_hash=%08lx charging_supported=%d",
+                 "Init context: first=%d rtc_version=0x%08lx battery_type=%d cap=%u term=%u cv=%.3f use_profile=%d profile_hash=%08lx charging_supported=%d",
                  firstBoot,
                  static_cast<unsigned long>(rtcStateVersion),
                  static_cast<int>(_batteryType),
                  static_cast<unsigned>(_batteryCapacity),
                  static_cast<unsigned>(_terminationCurrent),
-                 static_cast<unsigned>(_chargeVoltageMv),
+                 _chargeVoltage,
                  useProfile,
                  static_cast<unsigned long>(_profileHash),
                  chargingSupported);
@@ -797,29 +797,29 @@ namespace PowerFeather
                                     persistedChargerInitSignature.source == currentChargerInitSignature.source &&
                                     persistedChargerInitSignature.capacityMah == currentChargerInitSignature.capacityMah &&
                                     persistedChargerInitSignature.terminationCurrentMa == currentChargerInitSignature.terminationCurrentMa &&
-                                    persistedChargerInitSignature.chargeVoltageMv == currentChargerInitSignature.chargeVoltageMv &&
+                                    persistedChargerInitSignature.chargeVoltage == currentChargerInitSignature.chargeVoltage &&
                                     persistedChargerInitSignature.profileHash == currentChargerInitSignature.profileHash &&
                                     persistedChargerInitSignature.batteryExpected == currentChargerInitSignature.batteryExpected;
             ESP_LOGI(TAG,
-                     "Charger signature: match=%d persisted[src=%u cap=%u term=%u cv=%u hash=%08lx battery_expected=%d has_sig=%d] current[src=%u cap=%u term=%u cv=%u hash=%08lx battery_expected=%d] persisted_state[chg_en=%d ichg=%u ts=%d vindpm=%u]",
+                     "Charger signature: match=%d persisted[src=%u cap=%u term=%u cv=%.3f hash=%08lx battery_expected=%d has_sig=%d] current[src=%u cap=%u term=%u cv=%.3f hash=%08lx battery_expected=%d] persisted_state[chg_en=%d ichg=%.1f ts=%d vindpm=%.3f]",
                      chargerSignatureMatch,
                      static_cast<unsigned>(persistedChargerInitSignature.source),
                      static_cast<unsigned>(persistedChargerInitSignature.capacityMah),
                      static_cast<unsigned>(persistedChargerInitSignature.terminationCurrentMa),
-                     static_cast<unsigned>(persistedChargerInitSignature.chargeVoltageMv),
+                     persistedChargerInitSignature.chargeVoltage,
                      static_cast<unsigned long>(persistedChargerInitSignature.profileHash),
                      persistedChargerInitSignature.batteryExpected,
                      persistedChargerInitSignature.hasSignature,
                      static_cast<unsigned>(currentChargerInitSignature.source),
                      static_cast<unsigned>(currentChargerInitSignature.capacityMah),
                      static_cast<unsigned>(currentChargerInitSignature.terminationCurrentMa),
-                     static_cast<unsigned>(currentChargerInitSignature.chargeVoltageMv),
+                     currentChargerInitSignature.chargeVoltage,
                      static_cast<unsigned long>(currentChargerInitSignature.profileHash),
                      currentChargerInitSignature.batteryExpected,
                      persistedChargerState.chargingEnabled,
-                     static_cast<unsigned>(persistedChargerState.chargingCurrentLimit),
+                     persistedChargerState.chargingCurrentLimit,
                      persistedChargerState.tsEnabled,
-                     static_cast<unsigned>(persistedChargerState.vindpm));
+                     persistedChargerState.vindpm);
             if (chargerSignatureMatch)
             {
                 // Warm boot with unchanged battery/profile inputs: retain the
@@ -829,25 +829,25 @@ namespace PowerFeather
                 _tsEnabled = persistedChargerState.tsEnabled;
                 _vindpm = persistedChargerState.vindpm;
                 ESP_LOGI(TAG,
-                         "Rehydrated charger state from RTC: chg_en=%d ichg=%u ts=%d vindpm=%u",
+                         "Rehydrated charger state from RTC: chg_en=%d ichg=%.1f ts=%d vindpm=%.3f",
                          _chargingEnabled,
-                         static_cast<unsigned>(_chargingCurrentLimit),
+                         _chargingCurrentLimit,
                          _tsEnabled,
-                         static_cast<unsigned>(_vindpm));
+                         _vindpm);
             }
             else
             {
                 ESP_LOGI(TAG,
-                         "Warm boot with signature mismatch: keeping safe defaults chg_en=%d ichg=%u ts=%d vindpm=%u",
+                         "Warm boot with signature mismatch: keeping safe defaults chg_en=%d ichg=%.1f ts=%d vindpm=%.3f",
                          _chargingEnabled,
-                         static_cast<unsigned>(_chargingCurrentLimit),
+                         _chargingCurrentLimit,
                          _tsEnabled,
-                         static_cast<unsigned>(_vindpm));
+                         _vindpm);
             }
             _lastFuelGaugeInitSignature.source = static_cast<FuelGauge::InitSource>(persistedFuelGaugeInitSignature.source);
             _lastFuelGaugeInitSignature.capacityMah = persistedFuelGaugeInitSignature.capacityMah;
             _lastFuelGaugeInitSignature.terminationCurrentMa = persistedFuelGaugeInitSignature.terminationCurrentMa;
-            _lastFuelGaugeInitSignature.chargeVoltageMv = persistedFuelGaugeInitSignature.chargeVoltageMv;
+            _lastFuelGaugeInitSignature.chargeVoltage = persistedFuelGaugeInitSignature.chargeVoltage;
             _lastFuelGaugeInitSignature.profileHash = persistedFuelGaugeInitSignature.profileHash;
             _hasFuelGaugeInitSignature = persistedFuelGaugeInitSignature.hasSignature;
         }
@@ -865,7 +865,7 @@ namespace PowerFeather
             persistedFuelGaugeInitSignature.source = static_cast<uint8_t>(FuelGauge::InitSource::Generic_3V7);
             persistedFuelGaugeInitSignature.capacityMah = 0;
             persistedFuelGaugeInitSignature.terminationCurrentMa = 0;
-            persistedFuelGaugeInitSignature.chargeVoltageMv = 0;
+            persistedFuelGaugeInitSignature.chargeVoltage = 0.0f;
             persistedFuelGaugeInitSignature.profileHash = 0;
             persistedFuelGaugeInitSignature.hasSignature = false;
             persistedFuelGaugeLearnedState.hasState = false;
@@ -904,14 +904,14 @@ namespace PowerFeather
             RET_IF_FALSE(verifyChargerPart(getCharger()), Result::Failure);
 
             ESP_LOGI(TAG,
-                     "Applying charger init state: first=%d sig_match=%d chosen_state[chg_en=%d ichg=%u ts=%d vindpm=%u cv=%u]",
+                     "Applying charger init state: first=%d sig_match=%d chosen_state[chg_en=%d ichg=%.1f ts=%d vindpm=%.3f cv=%.3f]",
                      firstBoot,
                      chargerSignatureMatch,
                      _chargingEnabled,
-                     static_cast<unsigned>(_chargingCurrentLimit),
+                     _chargingCurrentLimit,
                      _tsEnabled,
-                     static_cast<unsigned>(_vindpm),
-                     static_cast<unsigned>(_chargeVoltageMv));
+                     _vindpm,
+                     _chargeVoltage);
             // _reapplyChargerConfig is gated on the charger watchdog (POR indicator).
             // On wdOn == true (first init, or chip POR since last init), it applies the
             // full configuration using the software state set above — which on a warm
@@ -923,7 +923,7 @@ namespace PowerFeather
             // Enforce charge voltage target on every init path, including the wdOn==false
             // path (chip retained state across sleep but we still want to rewrite VREG
             // in case the BatteryType chemistry selection changed since last session).
-            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
+            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltage), Result::Failure);
 
             if (_batteryCapacity && !chargingSupported)
             {
@@ -934,12 +934,12 @@ namespace PowerFeather
             if (firstBoot || !chargerSignatureMatch)
             {
                 ESP_LOGI(TAG,
-                         "%s: pushing software charger state into retained charger hardware chg_en=%d ichg=%u ts=%d vindpm=%u",
+                         "%s: pushing software charger state into retained charger hardware chg_en=%d ichg=%.1f ts=%d vindpm=%.3f",
                          firstBoot ? "Cold boot" : "Warm boot signature mismatch",
                          _chargingEnabled,
-                         static_cast<unsigned>(_chargingCurrentLimit),
+                         _chargingCurrentLimit,
                          _tsEnabled,
-                         static_cast<unsigned>(_vindpm));
+                         _vindpm);
                 // On a cold boot or a warm boot with changed battery/profile
                 // inputs, the charger may have retained the previous session's
                 // live state even though software intentionally selected safe
@@ -986,7 +986,7 @@ namespace PowerFeather
         persistedChargerInitSignature.source = currentChargerInitSignature.source;
         persistedChargerInitSignature.capacityMah = currentChargerInitSignature.capacityMah;
         persistedChargerInitSignature.terminationCurrentMa = currentChargerInitSignature.terminationCurrentMa;
-        persistedChargerInitSignature.chargeVoltageMv = currentChargerInitSignature.chargeVoltageMv;
+        persistedChargerInitSignature.chargeVoltage = currentChargerInitSignature.chargeVoltage;
         persistedChargerInitSignature.profileHash = currentChargerInitSignature.profileHash;
         persistedChargerInitSignature.batteryExpected = currentChargerInitSignature.batteryExpected;
         persistedChargerInitSignature.hasSignature = true;
@@ -1010,27 +1010,27 @@ namespace PowerFeather
                  static_cast<unsigned>(currentChargerInitSignature.source),
                  static_cast<unsigned>(currentChargerInitSignature.capacityMah),
                  static_cast<unsigned>(currentChargerInitSignature.terminationCurrentMa),
-                 static_cast<unsigned>(currentChargerInitSignature.chargeVoltageMv),
+                 currentChargerInitSignature.chargeVoltage,
                  static_cast<unsigned long>(currentChargerInitSignature.profileHash),
                  currentChargerInitSignature.batteryExpected,
                  _initDone,
                  static_cast<unsigned>(persistedChargerInitSignature.source),
                  static_cast<unsigned>(persistedChargerInitSignature.capacityMah),
                  static_cast<unsigned>(persistedChargerInitSignature.terminationCurrentMa),
-                 static_cast<unsigned>(persistedChargerInitSignature.chargeVoltageMv),
+                 persistedChargerInitSignature.chargeVoltage,
                  static_cast<unsigned long>(persistedChargerInitSignature.profileHash),
                  persistedChargerInitSignature.batteryExpected,
                  persistedChargerInitSignature.hasSignature,
                  static_cast<unsigned>(_lastFuelGaugeInitSignature.source),
                  static_cast<unsigned>(_lastFuelGaugeInitSignature.capacityMah),
                  static_cast<unsigned>(_lastFuelGaugeInitSignature.terminationCurrentMa),
-                 static_cast<unsigned>(_lastFuelGaugeInitSignature.chargeVoltageMv),
+                 _lastFuelGaugeInitSignature.chargeVoltage,
                  static_cast<unsigned long>(_lastFuelGaugeInitSignature.profileHash),
                  _hasFuelGaugeInitSignature,
                  static_cast<unsigned>(persistedFuelGaugeInitSignature.source),
                  static_cast<unsigned>(persistedFuelGaugeInitSignature.capacityMah),
                  static_cast<unsigned>(persistedFuelGaugeInitSignature.terminationCurrentMa),
-                 static_cast<unsigned>(persistedFuelGaugeInitSignature.chargeVoltageMv),
+                 persistedFuelGaugeInitSignature.chargeVoltage,
                  static_cast<unsigned long>(persistedFuelGaugeInitSignature.profileHash),
                  persistedFuelGaugeInitSignature.hasSignature);
 
@@ -1071,7 +1071,7 @@ namespace PowerFeather
             RET_IF_FALSE(_i2c.start(), Result::Failure);
             RET_IF_FALSE(verifyChargerPart(getCharger()), Result::Failure);
             RET_IF_ERR(_reapplyChargerConfig());
-            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
+            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltage), Result::Failure);
             _chargerADCTime = 0;
             if (_batteryCapacity)
             {
@@ -1098,25 +1098,25 @@ namespace PowerFeather
         return Result::Ok;
     }
 
-    Result Mainboard::getSupplyVoltage(uint16_t &voltage)
+    Result Mainboard::getSupplyVoltage(float &voltage)
     {
         TRY_LOCK(_mutex);
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_ERR(_udpateChargerADC());
         RET_IF_FALSE(getCharger().getVBUS(voltage), Result::Failure);
-        ESP_LOGD(TAG, "Measured supply voltage: %d mV.", voltage);
+        ESP_LOGD(TAG, "Measured supply voltage: %f V.", voltage);
         return Result::Ok;
     }
 
-    Result Mainboard::getSupplyCurrent(int16_t &current)
+    Result Mainboard::getSupplyCurrent(float &current)
     {
         TRY_LOCK(_mutex);
         RET_IF_FALSE(_initDone, Result::InvalidState);
         RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
         RET_IF_ERR(_udpateChargerADC());
         RET_IF_FALSE(getCharger().getIBUS(current), Result::Failure);
-        ESP_LOGD(TAG, "Measured supply current: %d mA.", current);
+        ESP_LOGD(TAG, "Measured supply current: %f mA.", current);
         return Result::Ok;
     }
 
@@ -1129,7 +1129,7 @@ namespace PowerFeather
         return Result::Ok;
     }
 
-    Result Mainboard::setSupplyMaintainVoltage(uint16_t voltage)
+    Result Mainboard::setSupplyMaintainVoltage(float voltage)
     {
         TRY_LOCK(_mutex);
         RET_IF_FALSE(_initDone, Result::InvalidState);
@@ -1139,7 +1139,7 @@ namespace PowerFeather
         RET_IF_FALSE(getCharger().setVINDPM(voltage), Result::Failure);
         _vindpm = voltage;
         persistedChargerState.vindpm = voltage;
-        ESP_LOGD(TAG, "Maintain supply voltage set to: %d mV.", voltage);
+        ESP_LOGD(TAG, "Maintain supply voltage set to: %f V.", voltage);
         return Result::Ok;
     }
 
@@ -1197,7 +1197,7 @@ namespace PowerFeather
         return Result::Ok;
     }
 
-    Result Mainboard::setBatteryChargingMaxCurrent(uint16_t current)
+    Result Mainboard::setBatteryChargingMaxCurrent(float current)
     {
         TRY_LOCK(_mutex);
         RET_IF_FALSE(_initDone, Result::InvalidState);
@@ -1209,7 +1209,7 @@ namespace PowerFeather
         RET_IF_FALSE(getCharger().setChargeCurrentLimit(current), Result::Failure);
         _chargingCurrentLimit = current;
         persistedChargerState.chargingCurrentLimit = current;
-        ESP_LOGD(TAG, "Max charging current set to: %d mA.", current);
+        ESP_LOGD(TAG, "Max charging current set to: %f mA.", current);
         return Result::Ok;
     }
 
@@ -1246,7 +1246,7 @@ namespace PowerFeather
         return Result::Ok;
     }
 
-    Result Mainboard::getBatteryVoltage(uint16_t &voltage)
+    Result Mainboard::getBatteryVoltage(float &voltage)
     {
         TRY_LOCK(_mutex);
         RET_IF_FALSE(_initDone, Result::InvalidState);
@@ -1267,7 +1267,7 @@ namespace PowerFeather
         return Result::Ok;
     }
 
-    Result Mainboard::getBatteryCurrent(int16_t &current)
+    Result Mainboard::getBatteryCurrent(float &current)
     {
         TRY_LOCK(_mutex);
         RET_IF_FALSE(_initDone, Result::InvalidState);
@@ -1275,7 +1275,7 @@ namespace PowerFeather
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
         RET_IF_ERR(_udpateChargerADC());
         RET_IF_FALSE(getCharger().getIBAT(current), Result::Failure);
-        ESP_LOGD(TAG, "Measured battery current from charger: %d mA.", current);
+        ESP_LOGD(TAG, "Measured battery current from charger: %f mA.", current);
         return Result::Ok;
     }
 
@@ -1328,9 +1328,9 @@ namespace PowerFeather
         RET_IF_FALSE(_isFuelGaugeEnabled(), Result::InvalidState);
         RET_IF_ERR(_initFuelGauge());
 
-        int16_t ibat = 0;
+        float ibat = 0.0f;
         RET_IF_ERR(getBatteryCurrent(ibat));
-        bool discharging = ibat <= 0;
+        bool discharging = ibat <= 0.0f;
 
         // Get the time-to-empty or time-to-full depending on battery is charging
         // or discharging.
@@ -1378,7 +1378,7 @@ namespace PowerFeather
         return Result::Ok;
     }
 
-    Result Mainboard::setBatteryLowVoltageAlarm(uint16_t voltage)
+    Result Mainboard::setBatteryLowVoltageAlarm(float voltage)
     {
         TRY_LOCK(_mutex);
         RET_IF_FALSE(_initDone, Result::InvalidState);
@@ -1386,8 +1386,8 @@ namespace PowerFeather
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
         RET_IF_FALSE(_isFuelGaugeEnabled(), Result::InvalidState);
         RET_IF_ERR(_initFuelGauge());
-        uint16_t minAlarm = 0;
-        uint16_t maxAlarm = 0;
+        float minAlarm = 0.0f;
+        float maxAlarm = 0.0f;
         getFuelGauge().getVoltageAlarmRange(minAlarm, maxAlarm);
         RET_IF_FALSE((voltage == 0) || (voltage >= minAlarm && voltage <= maxAlarm), Result::InvalidArg);
         RET_IF_FALSE(getFuelGauge().setLowVoltageAlarm(voltage), Result::Failure);
@@ -1395,11 +1395,11 @@ namespace PowerFeather
         {
             RET_IF_FALSE(getFuelGauge().clearLowVoltageAlarm(), Result::Failure);
         }
-        ESP_LOGD(TAG, "Low battery voltage alarm set to: %d mV.", voltage);
+        ESP_LOGD(TAG, "Low battery voltage alarm set to: %f V.", voltage);
         return Result::Ok;
     };
 
-    Result Mainboard::setBatteryHighVoltageAlarm(uint16_t voltage)
+    Result Mainboard::setBatteryHighVoltageAlarm(float voltage)
     {
         TRY_LOCK(_mutex);
         RET_IF_FALSE(_initDone, Result::InvalidState);
@@ -1407,8 +1407,8 @@ namespace PowerFeather
         RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
         RET_IF_FALSE(_isFuelGaugeEnabled(), Result::InvalidState);
         RET_IF_ERR(_initFuelGauge());
-        uint16_t minAlarm = 0;
-        uint16_t maxAlarm = 0;
+        float minAlarm = 0.0f;
+        float maxAlarm = 0.0f;
         getFuelGauge().getVoltageAlarmRange(minAlarm, maxAlarm);
         RET_IF_FALSE((voltage == 0) || (voltage >= minAlarm && voltage <= maxAlarm), Result::InvalidArg);
         RET_IF_FALSE(getFuelGauge().setHighVoltageAlarm(voltage), Result::Failure);
@@ -1416,7 +1416,7 @@ namespace PowerFeather
         {
             RET_IF_FALSE(getFuelGauge().clearHighVoltageAlarm(), Result::Failure);
         }
-        ESP_LOGD(TAG, "High battery voltage alarm set to: %d mV.", voltage);
+        ESP_LOGD(TAG, "High battery voltage alarm set to: %f V.", voltage);
         return Result::Ok;
     };
 

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -747,7 +747,7 @@ namespace PowerFeather
         RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxIINDPMCurrent), Result::Failure);
         RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
         RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
-        RET_IF_FALSE(getCharger().setBATFETDelay(BQ2562x::BATFETDelay::Delay20ms), Result::Failure);
+        RET_IF_FALSE(getCharger().setBATFETDelay(BQ2562x::BATFETDelay::Delay25ms), Result::Failure);
         RET_IF_FALSE(getCharger().enableWVBUS(true), Result::Failure);
         RET_IF_FALSE(getCharger().setTopOff(BQ2562x::TopOffTimer::Timer17Min), Result::Failure);
         // BQ25622E/BQ25628E currently document only 6 A and 12 A IBAT_PK values.

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -675,6 +675,41 @@ namespace PowerFeather
         return Result::Ok;
     }
 
+    Result Mainboard::_applyChargerConfig()
+    {
+        RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
+        RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxIINDPMCurrent), Result::Failure);
+        RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
+        RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
+        RET_IF_FALSE(getCharger().setBATFETDelay(BQ2562x::BATFETDelay::Delay20ms), Result::Failure);
+        RET_IF_FALSE(getCharger().enableWVBUS(true), Result::Failure);
+        RET_IF_FALSE(getCharger().setTopOff(BQ2562x::TopOffTimer::Timer17Min), Result::Failure);
+        // BQ25622E/BQ25628E currently document only 6 A and 12 A IBAT_PK values.
+        RET_IF_FALSE(getCharger().setIbatPk(BQ2562x::IbatPkLimit::Limit6A), Result::Failure);
+        RET_IF_FALSE(getCharger().setTH456(BQ2562x::TH456Setting::TH4_35_TH5_40_TH6_50), Result::Failure);
+        RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Precool, BQ2562x::TempIset::Ichg40), Result::Failure);
+        RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Prewarm, BQ2562x::TempIset::Ichg40), Result::Failure);
+        RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Cool, BQ2562x::TempIset::Ichg20), Result::Failure);
+        RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Warm, BQ2562x::TempIset::Ichg20), Result::Failure);
+        // Mask all interrupts first so POR-default unmasks don't leak through,
+        // then selectively re-enable only the ones the SDK actually uses.
+        RET_IF_FALSE(getCharger().enableInterrupts(false), Result::Failure);
+        if (_tsEnabled)
+        {
+            RET_IF_FALSE(getCharger().enableInterrupt(BQ2562x::Interrupt::TS, true), Result::Failure);
+        }
+        if (_batteryCapacity)
+        {
+            RET_IF_FALSE(getCharger().setITERM(_terminationCurrent), Result::Failure);
+        }
+        RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltage), Result::Failure);
+        RET_IF_FALSE(getCharger().setVINDPM(_vindpm), Result::Failure);
+        RET_IF_FALSE(getCharger().setWD(BQ2562x::WatchdogTimer::Disabled), Result::Failure);
+        RET_IF_FALSE(getCharger().enableCharging(_chargingEnabled), Result::Failure);
+
+        return Result::Ok;
+    }
+
     Result Mainboard::_reapplyChargerConfig()
     {
         bool wdOn = true;
@@ -683,35 +718,7 @@ namespace PowerFeather
         if (wdOn)
         {
             ESP_LOGW(TAG, "Charger watchdog enabled, re-applying configuration.");
-            RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
-            RET_IF_FALSE(getCharger().setIINDPM(BQ2562x::MaxIINDPMCurrent), Result::Failure);
-            RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
-            RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
-            RET_IF_FALSE(getCharger().setBATFETDelay(BQ2562x::BATFETDelay::Delay20ms), Result::Failure);
-            RET_IF_FALSE(getCharger().enableWVBUS(true), Result::Failure);
-            RET_IF_FALSE(getCharger().setTopOff(BQ2562x::TopOffTimer::Timer17Min), Result::Failure);
-            // BQ25622E/BQ25628E currently document only 6 A and 12 A IBAT_PK values.
-            RET_IF_FALSE(getCharger().setIbatPk(BQ2562x::IbatPkLimit::Limit6A), Result::Failure);
-            RET_IF_FALSE(getCharger().setTH456(BQ2562x::TH456Setting::TH4_35_TH5_40_TH6_50), Result::Failure);
-            RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Precool, BQ2562x::TempIset::Ichg40), Result::Failure);
-            RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Prewarm, BQ2562x::TempIset::Ichg40), Result::Failure);
-            RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Cool, BQ2562x::TempIset::Ichg20), Result::Failure);
-            RET_IF_FALSE(getCharger().setTempIset(BQ2562x::TempPoint::Warm, BQ2562x::TempIset::Ichg20), Result::Failure);
-            // Mask all interrupts first so POR-default unmasks don't leak through,
-            // then selectively re-enable only the ones the SDK actually uses.
-            RET_IF_FALSE(getCharger().enableInterrupts(false), Result::Failure);
-            if (_tsEnabled)
-            {
-                RET_IF_FALSE(getCharger().enableInterrupt(BQ2562x::Interrupt::TS, true), Result::Failure);
-            }
-            if (_batteryCapacity)
-            {
-                RET_IF_FALSE(getCharger().setITERM(_terminationCurrent), Result::Failure);
-            }
-            RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltage), Result::Failure);
-            RET_IF_FALSE(getCharger().setVINDPM(_vindpm), Result::Failure);
-            RET_IF_FALSE(getCharger().setWD(BQ2562x::WatchdogTimer::Disabled), Result::Failure);
-            RET_IF_FALSE(getCharger().enableCharging(_chargingEnabled), Result::Failure);
+            RET_IF_ERR(_applyChargerConfig());
         }
 
         return Result::Ok;
@@ -997,17 +1004,9 @@ namespace PowerFeather
                 // On a cold boot or a warm boot with changed battery/profile
                 // inputs, the charger may have retained the previous session's
                 // live state even though software intentionally selected safe
-                // defaults. Push those software-selected values into the
+                // defaults. Push the full software-selected policy into the
                 // retained hardware as well.
-                RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
-                RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
-                if (_batteryCapacity)
-                {
-                    RET_IF_FALSE(getCharger().setITERM(_terminationCurrent), Result::Failure);
-                }
-                RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
-                RET_IF_FALSE(getCharger().enableInterrupt(BQ2562x::Interrupt::TS, false), Result::Failure);
-                RET_IF_FALSE(getCharger().setVINDPM(_vindpm), Result::Failure);
+                RET_IF_ERR(_applyChargerConfig());
             }
 
             // If battery capacity is not 0, initialize the fuel gauge. This can fail if during

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -1334,6 +1334,13 @@ namespace PowerFeather
 #else
         RET_IF_ERR(_udpateChargerADC());
         RET_IF_FALSE(getCharger().getIBAT(current), Result::Failure);
+        bool chargingEnabled = false;
+        RET_IF_FALSE(getCharger().getChargingEnabled(chargingEnabled), Result::Failure);
+        if (!chargingEnabled && current == 0.0f)
+        {
+            ESP_LOGD(TAG, "V1 charger battery-current ADC is unavailable while charging is disabled.");
+            return Result::NotReady;
+        }
         ESP_LOGD(TAG, "Measured battery current from charger: %f mA.", current);
 #endif
         return Result::Ok;
@@ -1388,9 +1395,21 @@ namespace PowerFeather
         RET_IF_FALSE(_isFuelGaugeEnabled(), Result::InvalidState);
         RET_IF_ERR(_initFuelGauge());
 
+        bool discharging = true;
+#if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
         float ibat = 0.0f;
         RET_IF_ERR(getBatteryCurrent(ibat));
-        bool discharging = ibat <= 0.0f;
+        discharging = ibat <= 0.0f;
+#else
+        bool chargingEnabled = false;
+        RET_IF_FALSE(getCharger().getChargingEnabled(chargingEnabled), Result::Failure);
+        if (chargingEnabled)
+        {
+            float ibat = 0.0f;
+            RET_IF_ERR(getBatteryCurrent(ibat));
+            discharging = ibat <= 0.0f;
+        }
+#endif
 
         // Get the time-to-empty or time-to-full depending on battery is charging
         // or discharging.

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -816,11 +816,20 @@ namespace PowerFeather
         _usesProfile = useProfile;
         _profileHash = useProfile ? fnv1aHash(profile, sizeof(*profile)) : 0;
 
-        // Set termination current to C / 10, or within limits of the IC.
+        // Set termination current to C / 10 for built-in profiles, or to the
+        // characterized fuel-gauge value for custom MAX17260 profiles.
         uint16_t minCurrent = BQ2562x::MinITERMCurrent;
         uint16_t maxCurrent = BQ2562x::MaxITERMCurrent;
-        _terminationCurrent = static_cast<uint16_t>(_batteryCapacity / 10);
-        _terminationCurrent = std::min(std::max(_terminationCurrent, minCurrent), maxCurrent);
+        if (useProfile)
+        {
+            _terminationCurrent = MAX17260::ichgTermRawToMa(profile->ichgTerm);
+            RET_IF_FALSE(_terminationCurrent >= minCurrent && _terminationCurrent <= maxCurrent, Result::InvalidArg);
+        }
+        else
+        {
+            _terminationCurrent = static_cast<uint16_t>(_batteryCapacity / 10);
+            _terminationCurrent = std::min(std::max(_terminationCurrent, minCurrent), maxCurrent);
+        }
         ESP_LOGI(TAG, "Termination current set to %d mA.", _terminationCurrent);
 
         float chargeVoltage = 4.2f;

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -1320,12 +1320,8 @@ namespace PowerFeather
         return Result::Ok;
     }
 
-    Result Mainboard::getBatteryCurrent(float &current)
+    Result Mainboard::_getBatteryCurrentLocked(float &current)
     {
-        TRY_LOCK(_mutex);
-        RET_IF_FALSE(_initDone, Result::InvalidState);
-        RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
-        RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
         RET_IF_FALSE(_isFuelGaugeEnabled(), Result::InvalidState);
         RET_IF_ERR(_initFuelGauge());
@@ -1344,6 +1340,15 @@ namespace PowerFeather
         ESP_LOGD(TAG, "Measured battery current from charger: %f mA.", current);
 #endif
         return Result::Ok;
+    }
+
+    Result Mainboard::getBatteryCurrent(float &current)
+    {
+        TRY_LOCK(_mutex);
+        RET_IF_FALSE(_initDone, Result::InvalidState);
+        RET_IF_FALSE(_canAccessPowerI2C(), Result::InvalidState);
+        RET_IF_FALSE(_batteryCapacity, Result::InvalidState);
+        return _getBatteryCurrentLocked(current);
     }
 
     Result Mainboard::getBatteryCharge(uint8_t &percent)
@@ -1398,7 +1403,7 @@ namespace PowerFeather
         bool discharging = true;
 #if defined(CONFIG_ESP32S3_POWERFEATHER_V2) || defined(POWERFEATHER_BOARD_V2)
         float ibat = 0.0f;
-        RET_IF_ERR(getBatteryCurrent(ibat));
+        RET_IF_ERR(_getBatteryCurrentLocked(ibat));
         discharging = ibat <= 0.0f;
 #else
         bool chargingEnabled = false;
@@ -1406,7 +1411,7 @@ namespace PowerFeather
         if (chargingEnabled)
         {
             float ibat = 0.0f;
-            RET_IF_ERR(getBatteryCurrent(ibat));
+            RET_IF_ERR(_getBatteryCurrentLocked(ibat));
             discharging = ibat <= 0.0f;
         }
 #endif

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -146,6 +146,24 @@ namespace PowerFeather
             return signature;
         }
 
+        static bool verifyChargerPart(BQ2562x &charger)
+        {
+            uint8_t pi = 0;
+            if (!charger.getPartInformation(pi))
+            {
+                return false;
+            }
+
+            uint8_t pn = (pi >> 3) & 0x07;
+            if (pn != BQ2562x::Charger_PN_BQ25622 && pn != BQ2562x::Charger_PN_BQ25628)
+            {
+                ESP_LOGE(TAG, "Unsupported charger part ID: 0x%02x (expected PN: 0x%02x or 0x%02x)", pi, BQ2562x::Charger_PN_BQ25622, BQ2562x::Charger_PN_BQ25628);
+                return false;
+            }
+
+            return true;
+        }
+
         template <typename Gauge>
         struct FuelGaugeProfileHelper
         {
@@ -883,14 +901,7 @@ namespace PowerFeather
         {
             RET_IF_FALSE(_i2c.start(), Result::Failure);
 
-            uint8_t pi = 0;
-            RET_IF_FALSE(getCharger().getPartInformation(pi), Result::Failure);
-            uint8_t pn = (pi >> 3) & 0x07;
-            if (pn != BQ2562x::Charger_PN_BQ25622 && pn != BQ2562x::Charger_PN_BQ25628)
-            {
-                ESP_LOGE(TAG, "Unsupported charger part ID: 0x%02x (expected PN: 0x%02x or 0x%02x)", pi, BQ2562x::Charger_PN_BQ25622, BQ2562x::Charger_PN_BQ25628);
-                return Result::Failure;
-            }
+            RET_IF_FALSE(verifyChargerPart(getCharger()), Result::Failure);
 
             ESP_LOGI(TAG,
                      "Applying charger init state: first=%d sig_match=%d chosen_state[chg_en=%d ichg=%u ts=%d vindpm=%u cv=%u]",
@@ -936,6 +947,10 @@ namespace PowerFeather
                 // retained hardware as well.
                 RET_IF_FALSE(getCharger().enableCharging(false), Result::Failure);
                 RET_IF_FALSE(getCharger().setChargeCurrentLimit(_chargingCurrentLimit), Result::Failure);
+                if (_batteryCapacity)
+                {
+                    RET_IF_FALSE(getCharger().setITERM(_terminationCurrent), Result::Failure);
+                }
                 RET_IF_FALSE(getCharger().enableTS(_tsEnabled), Result::Failure);
                 RET_IF_FALSE(getCharger().enableInterrupt(BQ2562x::Interrupt::TS, false), Result::Failure);
                 RET_IF_FALSE(getCharger().setVINDPM(_vindpm), Result::Failure);
@@ -1054,6 +1069,7 @@ namespace PowerFeather
         if (enable && !_sqtEnabled)
         {
             RET_IF_FALSE(_i2c.start(), Result::Failure);
+            RET_IF_FALSE(verifyChargerPart(getCharger()), Result::Failure);
             RET_IF_ERR(_reapplyChargerConfig());
             RET_IF_FALSE(getCharger().setChargeVoltageLimit(_chargeVoltageMv), Result::Failure);
             _chargerADCTime = 0;

--- a/src/Mainboard/Mainboard.cpp
+++ b/src/Mainboard/Mainboard.cpp
@@ -592,7 +592,11 @@ namespace PowerFeather
             _mutex.lockBlocking();
 
             RET_IF_FALSE(getCharger().getADCDone(done) && done, Result::Failure);
-            _chargerADCTime = now;
+            // Record completion time (not entry time) so the throttle window measures
+            // idle time after the ADC settled, not entry-to-entry — otherwise back-to-back
+            // callers always satisfy (now - _chargerADCTime) >= _chargerADCWaitTime because
+            // the vTaskDelay above guarantees at least _chargerADCWaitTime has elapsed.
+            _chargerADCTime = esp_timer_get_time() / 1000;
             ESP_LOGD(TAG, "Updated charger ADC.");
         }
         return Result::Ok;

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -181,7 +181,9 @@ namespace PowerFeather
          * disabled and charge-current configuration is rejected.
          *
          * The profile must provide a valid charger constant-voltage target in \c chargeVoltage.
-         * Accepted range is 3.5-4.8 V.
+         * This value is applied directly to the charger VREG/CV limit. Accepted range is 3.5-4.8 V.
+         * The SDK does not infer a safe charge voltage from the custom model data; ensure this value
+         * matches the connected cell chemistry because an incorrect value can overcharge the cell.
          *
          * @param[in] profile MAX17260 model profile.
          *

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -150,6 +150,9 @@ namespace PowerFeather
          *  - Battery temperature sense: disabled
          *  - Battery alarms (low charge, high/low voltage): disabled
          *
+         * On RTC-retaining warm boots, charger settings changed through public setters are retained only when the
+         * battery or profile configuration still matches. If the configuration changes, initialization re-applies safe defaults.
+         *
          * This function should be called once, before calling all other \c Mainboard functions.
          *
          * @param[in] capacity The capacity of the connected Li-ion/LiPo battery in milliamp-hours (mAh).
@@ -213,9 +216,9 @@ namespace PowerFeather
          * Enables or disables \a VSQT, the 3.3 V STEMMA QT power output. When disabled, power to the
          * connected STEMMA QT modules is cut, reducing power consumption.
          *
-         * A side effect of disabling \a VSQT is that communications to the battery charger and fuel gauge is also disabled.
+         * On V1, disabling \a VSQT also disables communications to the battery charger and fuel gauge.
          * This means that some of the other \c Mainboard functions will return \c Result::InvalidState when
-         * \a VSQT is disabled. Make sure to enable \a VSQT prior to calling these functions.
+         * \a VSQT is disabled. On V2, power-management I2C remains usable even with \a VSQT disabled.
          *
          * @param[in] enable If \c true, \a VSQT is enabled; if \c false, \a VSQT is disabled.
          *
@@ -235,6 +238,9 @@ namespace PowerFeather
          * where the current extracted from the solar panel should be used to charge the battery as
          * much as possible.
          *
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
+         *
          * @param[in] enable If \c true, \a STAT LED is enabled; if \c false, \a STAT LED is disabled.
          *
          * @return Result Returns \c Result::Ok if \a STAT  LED was enabled or disabled successfully;
@@ -248,7 +254,8 @@ namespace PowerFeather
          * Measures the \a VUSB or \a VDC voltage. \a VUSB is the power input from the USB-C connector,
          * while \a VDC is the power input from the header pin. Resolution is 4 mV
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * This function can block for 100 ms.
          *
@@ -265,11 +272,12 @@ namespace PowerFeather
          * Measures the current drawn from \a VUSB or \a VDC. \a VUSB is the power input from the USB-C connector,
          * while \a VDC is the power input from the header pin. Resolution is 2 mA.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * This function can block for 100 ms.
          *
-         * @param[out] voltage The measured current draw in milliamperes (mA).
+         * @param[out] current The measured current draw in milliamperes (mA).
          *
          * @return Result Returns \c Result::Ok if the supply current was measured successfully;
          * returns a value other than \c Result::Ok if not.
@@ -296,9 +304,10 @@ namespace PowerFeather
          * the set voltage to maintain. This is useful for specifying the maximum power point (MPP) voltage if using a
          * solar panel; allowing the battery charger to extract power from the panel at near-MPPT effectiveness.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
-         * @param[in] voltage The supply voltage to maintain in millivolts (mV), up to 16800 mV.
+         * @param[in] voltage The supply voltage to maintain in millivolts (mV), from 4600 mV to 16800 mV.
          *
          * @return Result Returns \c Result::Ok if the supply voltage to maintain was set successfully;
          * returns a value other than \c Result::Ok if not.
@@ -317,7 +326,8 @@ namespace PowerFeather
          * Ship mode can be exited by either (1) pulling \a QON header pin low for around 800 ms or
          * (2) connecting a power supply which the battery charger determines to be good.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * This function can block for 30 ms if it fails to enter ship mode.
          *
@@ -338,7 +348,8 @@ namespace PowerFeather
          *
          * Shutdown mode can only be exited by connecting a power supply which the battery charger determines to be good.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * This function can block for 30 ms if it fails to enter shutdown mode.
          *
@@ -355,7 +366,8 @@ namespace PowerFeather
          * and loads connected to \a VS (supply output header pin, whichever of \a VUSB and \a VDC),
          * the power cycle provides complete reset by removing power and re-applying it after a short delay.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * @return Result Does not return if a power cycle was performed successfully;
          * returns a value other than \c Result::Ok if not.
@@ -367,7 +379,8 @@ namespace PowerFeather
          *
          * This is useful when opting to not fully charge a battery in order to prolong its lifespan.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -388,13 +401,14 @@ namespace PowerFeather
          * more than 1C. For example, when charging a 550 mAh battery, a current of no more than 550 mA is
          * recommended. That current limit of 550 mA can be specified using this function.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
          * On V2, this function is not available for configured battery capacities below 50 mAh.
          *
-         * @param[in] current The maximum charging current in milliamps (mA), up to 2000 mA.
+         * @param[in] current The maximum charging current in milliamps (mA), from 40 mA to 2000 mA.
          *
          * @return Result Returns \c Result::Ok if the maximum battery charging current was set successfully;
          * returns a value other than \c Result::Ok if not.
@@ -408,7 +422,8 @@ namespace PowerFeather
          * If enabled, aside from measurement, the battery charger performs temperature-based battery charging current
          * reduction or cutoff.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -429,7 +444,8 @@ namespace PowerFeather
          * Nonetheless, this is useful when trying to reduce power as much as possible, such as when going
          * into ship mode or shutdown mode for a long time.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -447,7 +463,8 @@ namespace PowerFeather
          * Resolution is 2 mV. If the fuel gauge is enabled and available, it is used;
          * otherwise, the charger VBAT ADC path is used as a fallback.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -469,7 +486,8 @@ namespace PowerFeather
          *
          * This overload uses the charger `IBAT_ADC` register on both V1 and V2, with a 4 mA LSb.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -490,7 +508,8 @@ namespace PowerFeather
          * Gives an estimate of battery state-of-charge from 0% to 100%. This is useful to get a sense
          * if the battery still has much charge or is nearly empty.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -510,7 +529,8 @@ namespace PowerFeather
          * Gives an estimate of battery state-of-health from 0% to 100%. This is useful to get a
          * sense of how much the battery has degraded over time.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -530,7 +550,8 @@ namespace PowerFeather
          * Gives an estimate of the battery cycle count. This is useful to compare against the number of
          * cycle counts the battery is rated for.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -551,7 +572,8 @@ namespace PowerFeather
          * previously dropped and/or risen by a certain percentage to be able to estimate time-to-empty or time-to-full, respectively.
          * If the gauge has not accumulated enough history yet, this function returns \c Result::NotReady.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -572,7 +594,11 @@ namespace PowerFeather
          * Requires a Semitec 103AT thermistor to be connected to the \a TS pin and attached to the battery
          * for the measurement to be accurate.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * Returns \c Result::Failure if the thermistor reading is outside the plausible range,
+         * such as when the thermistor is missing, open, or shorted.
+         *
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -594,7 +620,8 @@ namespace PowerFeather
          *
          * If battery voltage is less than the set voltage, the \a ALARM pin is pulled low.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -621,7 +648,8 @@ namespace PowerFeather
          *
          * If battery voltage is more than the set voltage, the \a ALARM pin is pulled low.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -648,7 +676,8 @@ namespace PowerFeather
          *
          * If battery charge is less than the set percentage, the \a ALARM pin is pulled low.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -679,7 +708,8 @@ namespace PowerFeather
          *  - V2: after initialization, fuel gauge temperature defaults to on-IC measurement until the first call to
          *        this API (or its no-arg overload), after which host-updated temperature is used.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
@@ -699,7 +729,8 @@ namespace PowerFeather
          * Equivalent to calling \c getBatteryTemperature() then \c updateBatteryFuelGaugeTemp(float).
          * See \c updateBatteryFuelGaugeTemp(float) for V1/V2 temperature mode behavior details.
          *
-         * \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
+         * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -184,6 +184,8 @@ namespace PowerFeather
          * This value is applied directly to the charger VREG/CV limit. Accepted range is 3.5-4.8 V.
          * The SDK does not infer a safe charge voltage from the custom model data; ensure this value
          * matches the connected cell chemistry because an incorrect value can overcharge the cell.
+         * The profile's \c ichgTerm is also applied to the charger termination-current setting after
+         * conversion from MAX17260 register units; it must correspond to 5-310 mA.
          *
          * @param[in] profile MAX17260 model profile.
          *

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -489,7 +489,9 @@ namespace PowerFeather
          *
          * Measures the current to or from the battery during charging and discharging, respectively.
          *
-         * On V1, this function uses the charger `IBAT_ADC` register with a 4 mA LSb.
+         * On V1, this function uses the charger `IBAT_ADC` register with a 4 mA LSb. The V1
+         * charger reports an ambiguous 0 mA while charging is disabled; in that case this
+         * function returns \c Result::NotReady instead of reporting a misleading zero current.
          * On V2, this function uses the MAX17260 `Current` register with a 0.078125 mA LSb.
          *
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
@@ -504,7 +506,8 @@ namespace PowerFeather
          * This function can block for 100 ms on V1.
          *
          * @param[out] current Measured battery current in milliamps (mA). If battery is discharging,
-         * this value is negative; positive if battery is charging.
+         * this value is negative; positive if battery is charging. On V1, this signed contract
+         * applies only when the charger provides a valid `IBAT_ADC` reading.
          *
          * @return Result Returns \c Result::Ok if the battery current was measured successfully;
          * returns a value other than \c Result::Ok if not.

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -790,6 +790,7 @@ namespace PowerFeather
 
 #if POWERFEATHER_ENABLE_PF_STATE_STREAM
         Result testRestoreFuelGaugeLearnedStateAfterPor();
+        Result testClearFuelGaugeInitSignature();
 #endif
 
         static Mainboard &get();

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -49,6 +49,10 @@
 #include "LC709204F.h"
 #include "MAX17260.h"
 
+#ifndef POWERFEATHER_ENABLE_PF_STATE_STREAM
+#define POWERFEATHER_ENABLE_PF_STATE_STREAM 0
+#endif
+
 namespace PowerFeather
 {
     class Mainboard
@@ -481,10 +485,10 @@ namespace PowerFeather
         /**
          * @brief Measure battery current.
          *
-         * Measures the current to or from the battery during charging and discharging, respectively, using the
-         * charger `IBAT_ADC` measurement path.
+         * Measures the current to or from the battery during charging and discharging, respectively.
          *
-         * This function uses the charger `IBAT_ADC` register on both V1 and V2, with a 4 mA LSb.
+         * On V1, this function uses the charger `IBAT_ADC` register with a 4 mA LSb.
+         * On V2, this function uses the MAX17260 `Current` register with a 0.078125 mA LSb.
          *
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          * On V2, power-management I2C remains usable with \a VSQT disabled.
@@ -492,7 +496,10 @@ namespace PowerFeather
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
          *
-         * This function can block for 100 ms.
+         * The battery fuel gauge must be enabled on V2 prior to calling this function, else
+         * \c Result::InvalidState is returned.
+         *
+         * This function can block for 100 ms on V1.
          *
          * @param[out] current Measured battery current in milliamps (mA). If battery is discharging,
          * this value is negative; positive if battery is charging.
@@ -753,6 +760,10 @@ namespace PowerFeather
          */
         FuelGauge &getFuelGauge();
 
+#if POWERFEATHER_ENABLE_PF_STATE_STREAM
+        Result testRestoreFuelGaugeLearnedStateAfterPor();
+#endif
+
         static Mainboard &get();
 
     private:
@@ -766,7 +777,6 @@ namespace PowerFeather
 
         static constexpr int _i2cPort = 1;
         static constexpr uint32_t _i2cFreq = 100000;
-        static constexpr uint32_t _i2cTimeout = 1000;
 
         static constexpr float _defaultMaxChargingCurrent = 50.0f; // minimum charge current at 1C
         static constexpr uint16_t _minChargeableBatteryCapacity = 50;

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -854,6 +854,7 @@ namespace PowerFeather
         Result _udpateChargerADC();
         Result _applyChargerConfig();
         Result _reapplyChargerConfig();
+        Result _getBatteryCurrentLocked(float &current);
 
         bool _isFuelGaugeEnabled();
         Result _initFuelGauge();

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -148,7 +148,7 @@ namespace PowerFeather
          *  - \a 3V3: enabled
          *  - \a VSQT: enabled
          *  - Charging: disabled
-         *  - Maximum battery charging current: 50 mA
+         *  - Maximum battery charging current request: 50 mA (programs 40 mA after BQ step quantization)
          *  - Maintain supply voltage: 4.6 V
          *  - Fuel gauge: enabled (use \c init() to disable)
          *  - Battery temperature sense: disabled
@@ -317,6 +317,8 @@ namespace PowerFeather
          * The battery charger dynamically regulates the current drawn from the supply to prevent it from collapsing under
          * the set voltage to maintain. This is useful for specifying the maximum power point (MPP) voltage if using a
          * solar panel; allowing the battery charger to extract power from the panel at near-MPPT effectiveness.
+         * This programs the charger's VINDPM request. The charger's effective regulation point can be higher when
+         * its battery-tracking behavior applies.
          *
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          * On V2, power-management I2C remains usable with \a VSQT disabled.
@@ -414,6 +416,8 @@ namespace PowerFeather
          * This is useful for batteries with small capacities, since it is not recommended to charge a battery at
          * more than 1C. For example, when charging a 550 mAh battery, a current of no more than 550 mA is
          * recommended. That current limit of 550 mA can be specified using this function.
+         * The charger encodes this limit in 40 mA steps; values between steps are rounded down so the programmed
+         * charger limit does not exceed the requested maximum.
          *
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          * On V2, power-management I2C remains usable with \a VSQT disabled.
@@ -423,6 +427,7 @@ namespace PowerFeather
          * On V2, this function is not available for configured battery capacities below 50 mAh.
          *
          * @param[in] current The maximum charging current in milliamps (mA), from 40 mA to 2000 mA.
+         * Values between 40 mA register steps are rounded down.
          *
          * @return Result Returns \c Result::Ok if the maximum battery charging current was set successfully;
          * returns a value other than \c Result::Ok if not.

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -263,7 +263,9 @@ namespace PowerFeather
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
-         * This function can block for 100 ms.
+         * This function can block for about 100 ms on a normal charger ADC refresh, plus
+         * power-management I2C transfer time. I2C faults can add one or more 50 ms transaction
+         * timeout windows before the function returns failure.
          *
          * @param[out] voltage The measured voltage in volts (V).
          *
@@ -281,7 +283,9 @@ namespace PowerFeather
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
-         * This function can block for 100 ms.
+         * This function can block for about 100 ms on a normal charger ADC refresh, plus
+         * power-management I2C transfer time. I2C faults can add one or more 50 ms transaction
+         * timeout windows before the function returns failure.
          *
          * @param[out] current The measured current draw in milliamperes (mA).
          *
@@ -475,7 +479,9 @@ namespace PowerFeather
          * A non-zero \p capacity or \p type of \c BatteryType::ICR18650_26H / \c BatteryType::UR18650ZY
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
          *
-         * This function can block for 100 ms.
+         * This function can block for about 100 ms plus power-management I2C transfer time when
+         * the charger ADC fallback path is used. I2C faults can add one or more 50 ms transaction
+         * timeout windows before the function returns failure.
          *
          * @param[out] voltage Measured battery voltage in volts (V).
          *
@@ -503,7 +509,9 @@ namespace PowerFeather
          * The battery fuel gauge must be enabled on V2 prior to calling this function, else
          * \c Result::InvalidState is returned.
          *
-         * This function can block for 100 ms on V1.
+         * This function can block for about 100 ms on a normal V1 charger ADC refresh, plus
+         * power-management I2C transfer time. I2C faults can add one or more 50 ms transaction
+         * timeout windows before the function returns failure.
          *
          * @param[out] current Measured battery current in milliamps (mA). If battery is discharging,
          * this value is negative; positive if battery is charging. On V1, this signed contract
@@ -618,7 +626,9 @@ namespace PowerFeather
          * Battery temperature measurement must be enabled prior calling this function, else \c Result::InvalidState
          * is returned.
          *
-         * This function can block for 100 ms.
+         * This function can block for about 100 ms on a normal charger ADC refresh, plus
+         * power-management I2C transfer time. I2C faults can add one or more 50 ms transaction
+         * timeout windows before the function returns failure.
          *
          * @param[out] celsius Measured battery temperature in celsius.
          *

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -145,7 +145,7 @@ namespace PowerFeather
          *  - \a VSQT: enabled
          *  - Charging: disabled
          *  - Maximum battery charging current: 50 mA
-         *  - Maintain supply voltage: 4600 mV
+         *  - Maintain supply voltage: 4.6 V
          *  - Fuel gauge: enabled (use \c init() to disable)
          *  - Battery temperature sense: disabled
          *  - Battery alarms (low charge, high/low voltage): disabled
@@ -176,8 +176,8 @@ namespace PowerFeather
          * On V2, inferred capacities below 50 mAh are supported for monitoring only: battery charging remains
          * disabled and charge-current configuration is rejected.
          *
-         * The profile must provide a valid charger constant-voltage target in \c chargeVoltageMv.
-         * Accepted range is 3500-4800 mV.
+         * The profile must provide a valid charger constant-voltage target in \c chargeVoltage.
+         * Accepted range is 3.5-4.8 V.
          *
          * @param[in] profile MAX17260 model profile.
          *
@@ -252,19 +252,19 @@ namespace PowerFeather
          * @brief Measure the supply voltage.
          *
          * Measures the \a VUSB or \a VDC voltage. \a VUSB is the power input from the USB-C connector,
-         * while \a VDC is the power input from the header pin. Resolution is 4 mV
+         * while \a VDC is the power input from the header pin. Resolution is approximately 0.004 V.
          *
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * This function can block for 100 ms.
          *
-         * @param[out] voltage The measured voltage in millivolts (mV).
+         * @param[out] voltage The measured voltage in volts (V).
          *
          * @return Result Returns \c Result::Ok if the supply voltage was measured successfully;
          * returns a value other than \c Result::Ok if not.
          */
-        Result getSupplyVoltage(uint16_t &voltage);
+        Result getSupplyVoltage(float &voltage);
 
         /**
          * @brief Measure the supply current.
@@ -282,7 +282,7 @@ namespace PowerFeather
          * @return Result Returns \c Result::Ok if the supply current was measured successfully;
          * returns a value other than \c Result::Ok if not.
          */
-        Result getSupplyCurrent(int16_t &current);
+        Result getSupplyCurrent(float &current);
 
         /**
          * @brief Check if the supply is good.
@@ -307,12 +307,12 @@ namespace PowerFeather
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
-         * @param[in] voltage The supply voltage to maintain in millivolts (mV), from 4600 mV to 16800 mV.
+         * @param[in] voltage The supply voltage to maintain in volts (V), from 4.6 V to 16.8 V.
          *
          * @return Result Returns \c Result::Ok if the supply voltage to maintain was set successfully;
          * returns a value other than \c Result::Ok if not.
          */
-        Result setSupplyMaintainVoltage(uint16_t voltage);
+        Result setSupplyMaintainVoltage(float voltage);
 
         /**
          * @brief Enter ship mode.
@@ -413,7 +413,7 @@ namespace PowerFeather
          * @return Result Returns \c Result::Ok if the maximum battery charging current was set successfully;
          * returns a value other than \c Result::Ok if not.
          */
-        Result setBatteryChargingMaxCurrent(uint16_t current);
+        Result setBatteryChargingMaxCurrent(float current);
 
         /**
          * @brief Enable or disable battery temperature measurement.
@@ -460,7 +460,7 @@ namespace PowerFeather
         /**
          * @brief Measure battery voltage.
          *
-         * Resolution is 2 mV. If the fuel gauge is enabled and available, it is used;
+         * Resolution is approximately 0.002 V. If the fuel gauge is enabled and available, it is used;
          * otherwise, the charger VBAT ADC path is used as a fallback.
          *
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
@@ -471,12 +471,12 @@ namespace PowerFeather
          *
          * This function can block for 100 ms.
          *
-         * @param[out] voltage Measured battery voltage in millivolts (mV).
+         * @param[out] voltage Measured battery voltage in volts (V).
          *
          * @return Result Returns \c Result::Ok if the battery voltage was measured successfully;
          * returns a value other than \c Result::Ok if not.
          */
-        Result getBatteryVoltage(uint16_t &voltage);
+        Result getBatteryVoltage(float &voltage);
 
         /**
          * @brief Measure battery current.
@@ -484,7 +484,7 @@ namespace PowerFeather
          * Measures the current to or from the battery during charging and discharging, respectively, using the
          * charger `IBAT_ADC` measurement path.
          *
-         * This overload uses the charger `IBAT_ADC` register on both V1 and V2, with a 4 mA LSb.
+         * This function uses the charger `IBAT_ADC` register on both V1 and V2, with a 4 mA LSb.
          *
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          * On V2, power-management I2C remains usable with \a VSQT disabled.
@@ -500,7 +500,7 @@ namespace PowerFeather
          * @return Result Returns \c Result::Ok if the battery current was measured successfully;
          * returns a value other than \c Result::Ok if not.
          */
-        Result getBatteryCurrent(int16_t &current);
+        Result getBatteryCurrent(float &current);
 
         /**
          * @brief Estimate battery charge.
@@ -628,20 +628,20 @@ namespace PowerFeather
          *
          * The battery fuel gauge must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          *
-         * @param[in] voltage The voltage at which the low voltage alarm will trigger in millivolts (mV).
-         * Valid non-zero range depends on board revision (2500-5000 mV for V1, 20-5100 mV for V2). If zero,
+         * @param[in] voltage The voltage at which the low voltage alarm will trigger in volts (V).
+         * Valid non-zero range depends on board revision (2.5-5.0 V for V1, 0.02-5.1 V for V2). If zero,
          * triggering of the alarm is disabled and any existing low voltage
          * alarm is cleared.
          *
          * Alarm handling differs by board revision:
          *  - V1 (LC709204F): low-voltage status naturally clears once voltage returns above threshold.
          *  - V2 (MAX17260): low-voltage status is latched until explicitly cleared.
-         *    Use \c setBatteryLowVoltageAlarm(0) to clear, then set a non-zero threshold to re-arm.
+         *    Use \c setBatteryLowVoltageAlarm(0.0f) to clear, then set a non-zero threshold to re-arm.
          *
          * @return Result Returns \c Result::Ok if the battery low voltage alarm was set successfully;
          * returns a value other than \c Result::Ok if not.
          */
-        Result setBatteryLowVoltageAlarm(uint16_t voltage);
+        Result setBatteryLowVoltageAlarm(float voltage);
 
         /**
          * @brief Set an alarm for battery high voltage.
@@ -656,20 +656,20 @@ namespace PowerFeather
          *
          * The battery fuel gauge must be enabled prior to calling this function, else \c Result::InvalidState is returned.
          *
-         * @param[in] voltage The voltage at which the high voltage alarm will trigger in millovolts (mV).
-         * Valid non-zero range depends on board revision (2500-5000 mV for V1, 20-5100 mV for V2). If zero,
+         * @param[in] voltage The voltage at which the high voltage alarm will trigger in volts (V).
+         * Valid non-zero range depends on board revision (2.5-5.0 V for V1, 0.02-5.1 V for V2). If zero,
          * triggering of the alarm is disabled and any existing high voltage
          * alarm is cleared.
          *
          * Alarm handling differs by board revision:
          *  - V1 (LC709204F): high-voltage status naturally clears once voltage returns below threshold.
          *  - V2 (MAX17260): high-voltage status is latched until explicitly cleared.
-         *    Use \c setBatteryHighVoltageAlarm(0) to clear, then set a non-zero threshold to re-arm.
+         *    Use \c setBatteryHighVoltageAlarm(0.0f) to clear, then set a non-zero threshold to re-arm.
          *
          * @return Result Returns \c Result::Ok if the battery high voltage alarm was set successfully;
          * returns a value other than \c Result::Ok if not.
          */
-        Result setBatteryHighVoltageAlarm(uint16_t voltage);
+        Result setBatteryHighVoltageAlarm(float voltage);
 
         /**
          * @brief Set an alarm for battery low charge.
@@ -768,9 +768,9 @@ namespace PowerFeather
         static constexpr uint32_t _i2cFreq = 100000;
         static constexpr uint32_t _i2cTimeout = 1000;
 
-        static constexpr uint16_t _defaultMaxChargingCurrent = 50; // minimum charge current at 1C
-        static constexpr uint16_t _minChargeableBatteryCapacity = _defaultMaxChargingCurrent;
-        static constexpr uint16_t _minSupplyMaintainVoltage = BQ2562x::ResetVINDPMVoltage;
+        static constexpr float _defaultMaxChargingCurrent = 50.0f; // minimum charge current at 1C
+        static constexpr uint16_t _minChargeableBatteryCapacity = 50;
+        static constexpr float _minSupplyMaintainVoltage = BQ2562x::ResetVINDPMVoltage;
 
         static_assert(_minSupplyMaintainVoltage >= BQ2562x::MinVINDPMVoltage);
         static_assert(_defaultMaxChargingCurrent >= BQ2562x::MinChargingCurrent);
@@ -783,7 +783,7 @@ namespace PowerFeather
             FuelGauge::InitSource source{FuelGauge::InitSource::Generic_3V7};
             uint16_t capacityMah{0};
             uint16_t terminationCurrentMa{0};
-            uint16_t chargeVoltageMv{0};
+            float chargeVoltage{0.0f};
             uint32_t profileHash{0};
         };
 
@@ -803,9 +803,9 @@ namespace PowerFeather
         uint32_t _chargerADCTime{0};
         uint16_t _batteryCapacity{0};
         uint16_t _terminationCurrent{0};
-        uint16_t _chargeVoltageMv{4200};
-        uint16_t _chargingCurrentLimit{_defaultMaxChargingCurrent};
-        uint16_t _vindpm{_minSupplyMaintainVoltage};
+        float _chargeVoltage{4.2f};
+        float _chargingCurrentLimit{_defaultMaxChargingCurrent};
+        float _vindpm{_minSupplyMaintainVoltage};
         uint32_t _profileHash{0};
         bool _tsEnabled{false};
         bool _chargingEnabled{false};

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -264,8 +264,9 @@ namespace PowerFeather
          * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * This function can block for about 100 ms on a normal charger ADC refresh, plus
-         * power-management I2C transfer time. I2C faults can add one or more 50 ms transaction
-         * timeout windows before the function returns failure.
+         * power-management I2C transfer time. I2C faults can add several 50 ms transaction
+         * timeout windows before the function returns failure; tasks contending for the SDK
+         * mutex are bounded by the mutex timeout while this call waits for the ADC conversion.
          *
          * @param[out] voltage The measured voltage in volts (V).
          *
@@ -284,8 +285,9 @@ namespace PowerFeather
          * On V2, power-management I2C remains usable with \a VSQT disabled.
          *
          * This function can block for about 100 ms on a normal charger ADC refresh, plus
-         * power-management I2C transfer time. I2C faults can add one or more 50 ms transaction
-         * timeout windows before the function returns failure.
+         * power-management I2C transfer time. I2C faults can add several 50 ms transaction
+         * timeout windows before the function returns failure; tasks contending for the SDK
+         * mutex are bounded by the mutex timeout while this call waits for the ADC conversion.
          *
          * @param[out] current The measured current draw in milliamperes (mA).
          *
@@ -480,8 +482,9 @@ namespace PowerFeather
          * should have been specified when \c MainBoard::init was called, else \c Result::InvalidState is returned.
          *
          * This function can block for about 100 ms plus power-management I2C transfer time when
-         * the charger ADC fallback path is used. I2C faults can add one or more 50 ms transaction
-         * timeout windows before the function returns failure.
+         * the charger ADC fallback path is used. I2C faults can add several 50 ms transaction
+         * timeout windows before the function returns failure; tasks contending for the SDK
+         * mutex are bounded by the mutex timeout while this call waits for the ADC conversion.
          *
          * @param[out] voltage Measured battery voltage in volts (V).
          *
@@ -495,9 +498,10 @@ namespace PowerFeather
          *
          * Measures the current to or from the battery during charging and discharging, respectively.
          *
-         * On V1, this function uses the charger `IBAT_ADC` register with a 4 mA LSb. The V1
-         * charger reports an ambiguous 0 mA while charging is disabled; in that case this
-         * function returns \c Result::NotReady instead of reporting a misleading zero current.
+         * On V1, this function uses the charger `IBAT_ADC` register with a 4 mA LSb. BQ25628E
+         * Table 8-35 specifies that `IBAT_ADC` resets to zero when charging is disabled; in
+         * that case this function returns \c Result::NotReady instead of reporting a
+         * misleading zero current.
          * On V2, this function uses the MAX17260 `Current` register with a 0.078125 mA LSb.
          *
          * On V1, \a VSQT must be enabled prior to calling this function, else \c Result::InvalidState is returned.
@@ -510,8 +514,9 @@ namespace PowerFeather
          * \c Result::InvalidState is returned.
          *
          * This function can block for about 100 ms on a normal V1 charger ADC refresh, plus
-         * power-management I2C transfer time. I2C faults can add one or more 50 ms transaction
-         * timeout windows before the function returns failure.
+         * power-management I2C transfer time. I2C faults can add several 50 ms transaction
+         * timeout windows before the function returns failure; tasks contending for the SDK
+         * mutex are bounded by the mutex timeout while this call waits for the ADC conversion.
          *
          * @param[out] current Measured battery current in milliamps (mA). If battery is discharging,
          * this value is negative; positive if battery is charging. On V1, this signed contract
@@ -627,8 +632,9 @@ namespace PowerFeather
          * is returned.
          *
          * This function can block for about 100 ms on a normal charger ADC refresh, plus
-         * power-management I2C transfer time. I2C faults can add one or more 50 ms transaction
-         * timeout windows before the function returns failure.
+         * power-management I2C transfer time. I2C faults can add several 50 ms transaction
+         * timeout windows before the function returns failure; tasks contending for the SDK
+         * mutex are bounded by the mutex timeout while this call waits for the ADC conversion.
          *
          * @param[out] celsius Measured battery temperature in celsius.
          *
@@ -853,7 +859,7 @@ namespace PowerFeather
         Result _initInternal(uint16_t capacity, BatteryType type, const MAX17260::Model *profile);
         Result _udpateChargerADC();
         Result _applyChargerConfig();
-        Result _reapplyChargerConfig();
+        Result _reapplyChargerConfig(bool *applied = nullptr);
         Result _getBatteryCurrentLocked(float &current);
 
         bool _isFuelGaugeEnabled();

--- a/src/Mainboard/Mainboard.h
+++ b/src/Mainboard/Mainboard.h
@@ -839,6 +839,7 @@ namespace PowerFeather
         uint16_t _capacityFromProfile(const MAX17260::Model &profile) const;
         Result _initInternal(uint16_t capacity, BatteryType type, const MAX17260::Model *profile);
         Result _udpateChargerADC();
+        Result _applyChargerConfig();
         Result _reapplyChargerConfig();
 
         bool _isFuelGaugeEnabled();

--- a/src/Utils/ArduinoMasterI2C.cpp
+++ b/src/Utils/ArduinoMasterI2C.cpp
@@ -44,7 +44,12 @@ namespace PowerFeather
     {
         _wire = (_port == 0) ? &Wire : &Wire1;
         ESP_LOGD(TAG, "Start Wire%d with sda: %d, scl: %d and freq: %d.", _port, _sdaPin, _sclPin, _freq);
-        return _wire->begin(_sdaPin, _sclPin, _freq);
+        if (!_wire->begin(_sdaPin, _sclPin, _freq))
+        {
+            return false;
+        }
+        _wire->setTimeOut(TransferTimeoutMs);
+        return true;
     }
 
     bool ArduinoMasterI2C::write(uint8_t address, uint8_t reg, const uint8_t *buf, size_t len)

--- a/src/Utils/MasterI2C.cpp
+++ b/src/Utils/MasterI2C.cpp
@@ -126,7 +126,7 @@ namespace PowerFeather
         memcpy(&(buf2[sizeof(reg)]), buf, len);
         ESP_LOGV(TAG, "Write address: %02x, reg: %02x, buf: %p, len: %d.", address, reg, buf, len);
         ESP_LOG_BUFFER_HEX_LEVEL(TAG, buf, len, ESP_LOG_VERBOSE);
-        return i2c_master_transmit(device, buf2, sizeof(buf2), _transferTimeoutMs) == ESP_OK;
+        return i2c_master_transmit(device, buf2, sizeof(buf2), TransferTimeoutMs) == ESP_OK;
     }
 
     bool MasterI2C::read(uint8_t address, uint8_t reg, uint8_t *buf, size_t len)
@@ -138,7 +138,7 @@ namespace PowerFeather
         }
 
         ESP_LOGV(TAG, "Read address: %02x, reg: %02x, buf: %p, len: %d.", address, reg, buf, len);
-        esp_err_t res = i2c_master_transmit_receive(device, &reg, sizeof(reg), buf, len, _transferTimeoutMs);
+        esp_err_t res = i2c_master_transmit_receive(device, &reg, sizeof(reg), buf, len, TransferTimeoutMs);
         ESP_LOG_BUFFER_HEX_LEVEL(TAG, buf, len, ESP_LOG_VERBOSE);
         return res == ESP_OK;
     }

--- a/src/Utils/MasterI2C.h
+++ b/src/Utils/MasterI2C.h
@@ -60,6 +60,8 @@ namespace PowerFeather
         virtual bool write(uint8_t address, uint8_t reg, const uint8_t *buf, size_t len);
         virtual bool read(uint8_t address, uint8_t reg, uint8_t *buf, size_t len);
 
+        static constexpr int TransferTimeoutMs = 50;
+
     protected:
 #ifndef ARDUINO
         i2c_port_num_t _port;
@@ -80,7 +82,6 @@ namespace PowerFeather
 
         static constexpr uint8_t _firstInvalid7BitAddress = 0x80;
         static constexpr size_t _maxDevices = 8;
-        static constexpr int _transferTimeoutMs = 1000;
 
         bool _getDevice(uint8_t address, i2c_master_dev_handle_t &device);
 

--- a/src/Utils/Mutex.h
+++ b/src/Utils/Mutex.h
@@ -46,7 +46,13 @@ namespace PowerFeather
         {
         public:
             Lock(Mutex &mutex) : _mutex(mutex) { _locked = _mutex.lock(); }
-            ~Lock() { _mutex.unlock(); }
+            ~Lock()
+            {
+                if (_locked)
+                {
+                    _mutex.unlock();
+                }
+            }
 
             bool isLocked() { return _locked; }
 


### PR DESCRIPTION
- Use floats in API instead of integer types; voltage values are now in V, current values remain mA
- Fix issues found by LLMs